### PR TITLE
Disable defaulting new users to the Tag "administrator"

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Management.Client.Model
             {
                 return tagList.Any()
                     ? string.Join(",", tagList)
-                    : allowedTags.First();
+                    : string.Empty;
 
             }
         }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ.Management.Client version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.47.12.0")]
+[assembly: AssemblyVersion("0.48.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-
+// 0.48.0.0 removing the default tag "administrator" when creating new users via the management api
 // 0.47.12.0 adding Partition model and Node.Partitions prop
 // 0.47.11.0 Now Management.Client has separate from EasyNetQ version
 // 0.47.10.0 RabbitHutch.CreateBus overloads

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,12 @@
 using System.Reflection;
 
 // EasyNetQ.Management.Client version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.48.0.0")]
+[assembly: AssemblyVersion("0.47.13.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-// 0.48.0.0 removing the default tag "administrator" when creating new users via the management api
+
+// 0.47.13.0 removing the default tag "administrator" when creating new users via the management api
 // 0.47.12.0 adding Partition model and Node.Partitions prop
 // 0.47.11.0 Now Management.Client has separate from EasyNetQ version
 // 0.47.10.0 RabbitHutch.CreateBus overloads


### PR DESCRIPTION
Previously, when creating a new user without any tag, he automatically got the "administrator" Tag. This is bad because in this way it is not possible to create a application user without any management Permissions.
I am just implementing an application that automatically creates many users. These users should not be allowed to access the management API, they are just allowed to access queues and exchanges but not the management API (other port). RabbitMq registers an users with an empty string tag "" as a "normal user".