### PR TITLE
Preserve Parameter key case via RabbitContractResolver

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace EasyNetQ.Management.Client.Model
 {

--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -12,10 +12,7 @@ namespace EasyNetQ.Management.Client.Model
         {
             get
             {
-                return tagList.Any()
-                    ? string.Join(",", tagList)
-                    : allowedTags.First();
-
+                return string.Join(",", tagList);
             }
         }
         private readonly ISet<string> allowedTags = new HashSet<string>

--- a/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
+++ b/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
@@ -10,10 +10,10 @@ namespace EasyNetQ.Management.Client
             return Regex.Replace(propertyName, "([a-z])([A-Z])", "$1_$2").ToLower();
         }
         protected override JsonDictionaryContract CreateDictionaryContract(Type objectType)
-		{
-			var c = base.CreateDictionaryContract(objectType);
-			c.PropertyNameResolver = null;
-			return c;
-		}
+        {
+            var c = base.CreateDictionaryContract(objectType);
+            c.PropertyNameResolver = null;
+            return c;
+        }
     }
 }

--- a/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
+++ b/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
@@ -9,5 +9,11 @@ namespace EasyNetQ.Management.Client
         {
             return Regex.Replace(propertyName, "([a-z])([A-Z])", "$1_$2").ToLower();
         }
+        protected override JsonDictionaryContract CreateDictionaryContract(Type objectType)
+		{
+			var c = base.CreateDictionaryContract(objectType);
+			c.PropertyNameResolver = null;
+			return c;
+		}
     }
 }

--- a/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
+++ b/Source/EasyNetQ.Management.Client/RabbitContractResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+using System;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Serialization;
 
 namespace EasyNetQ.Management.Client


### PR DESCRIPTION
The RabbitContractResolver caused Parameters keys to be converted to lower case, this is bad for headers binding. rabbitmq treats any x- (note lowercase) prefixed parameters as arguments and not headers.

Returning the first item in the user tag list caused a simple user addition to be an administrator.
