### PR TITLE
Don´t serialize null members

### DIFF
--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -29,6 +29,7 @@ namespace EasyNetQ.Management.Client
             Settings = new JsonSerializerSettings
             {
                 ContractResolver = new RabbitContractResolver(),
+                NullValueHandling = NullValueHandling.Ignore,
             };
 
             Settings.Converters.Add(new PropertyConverter());

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ.Management.Client version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.48.21.0")]
+[assembly: AssemblyVersion("0.48.22.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.48.22.0 Fixed serialization for null members on create a parameter
 // 0.48.21.0 Fixed error on create a parameter
 // 0.48.20.0 Escape # with %23 for a queue name
 // 0.47.20.0 Fixed serialization exception for cases when queue.consumer_details[0].channel_details.peer_port="unknown"


### PR DESCRIPTION
When a try create a parameter (using CreateParameter method) JsonSerializer is generate null members, this return error 500 on Rabbit server.
With option NullValueHandling = NullValueHandling.Ignore these members will not be generate.