### PR TITLE
Fixes #22 removed the default user tag "administrator" when creating new user

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
@@ -46,9 +46,9 @@ namespace EasyNetQ.Management.Client.Tests.Model
         }
 
         [Test]
-        public void Should_have_a_default_tag_of_administrator()
+        public void Should_have_a_default_tag_of_empty_string()
         {
-            userInfo.Tags.ShouldEqual("administrator");
+            userInfo.Tags.ShouldEqual("");
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -14,7 +14,7 @@ namespace EasyNetQ.Management.Client.Model
             {
                 return tagList.Any()
                     ? string.Join(",", tagList)
-                    : allowedTags.First();
+                    : string.Empty;
 
             }
         }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,10 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ.Management.Client version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.48.22.0")]
+[assembly: AssemblyVersion("0.48.23.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.48.23.0 Removed the default user tag "administrator" when creating new users via the management api
 // 0.48.22.0 Fixed serialization for null members on create a parameter
 // 0.48.21.0 Fixed error on create a parameter
 // 0.48.20.0 Escape # with %23 for a queue name

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -2,11 +2,11 @@
 using System.Reflection;
 
 // EasyNetQ.Management.Client version number: <major>.<minor>.<non-breaking-feature>.<build>
-[assembly: AssemblyVersion("0.48.23.0")]
+[assembly: AssemblyVersion("0.49.0.0")]
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
-// 0.48.23.0 Removed the default user tag "administrator" when creating new users via the management api
+// 0.49.0.0 Removed the default user tag "administrator" when creating new users via the management api
 // 0.48.22.0 Fixed serialization for null members on create a parameter
 // 0.48.21.0 Fixed error on create a parameter
 // 0.48.20.0 Escape # with %23 for a queue name

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -58,3 +58,4 @@ No particular order. Don't forget to add your name with your pull request.
 * Mathieu Leenhardt
 * Steven Bone
 * Ryan Chappell
+* Alex Wiese


### PR DESCRIPTION
Fixes #22 
Removed the default user tag "administrator" when creating new users via the management api