### PR TITLE
Modified long for Queue.Memory/Node.Mem* type

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/Node.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Node.cs
@@ -9,13 +9,13 @@ namespace EasyNetQ.Management.Client.Model
         public string Type { get; set; }
         public bool Running { get; set; }
         public string OsPid { get; set; }
-        public int MemEts { get; set; }
-        public int MemBinary { get; set; }
-        public int MemProc { get; set; }
-        public int MemProcUsed { get; set; }
-        public int MemAtom { get; set; }
-        public int MemAtomUsed { get; set; }
-        public int MemCode { get; set; }
+        public long MemEts { get; set; }
+        public long MemBinary { get; set; }
+        public long MemProc { get; set; }
+        public long MemProcUsed { get; set; }
+        public long MemAtom { get; set; }
+        public long MemAtomUsed { get; set; }
+        public long MemCode { get; set; }
         public string FdUsed { get; set; }
         public int FdTotal { get; set; }
         public int SocketsUsed { get; set; }

--- a/Source/EasyNetQ.Management.Client/Model/Queue.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Queue.cs
@@ -4,7 +4,7 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class Queue
     {
-        public int Memory { get; set; }
+        public long Memory { get; set; }
         public string IdleSince { get; set; }
         public string Policy { get; set; }
         public string ExclusiveConsumerTag { get; set; }

--- a/Source/Version.cs
+++ b/Source/Version.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 [assembly: CLSCompliant(true)]
 
 // Note: until version 1.0 expect breaking changes on 0.X versions.
+// 0.51.1.0 Modified long for Queue.Memory/Node.Mem* type
 // 0.51.0.0 Consolidated the way queue lengths and message rates are being returned. Updated to the post 3.1.0 api format.
 // 0.50.2.0 Escape / with %2f for exchange and queue names
 // 0.50.1.0 RabbitMq 3.7.0 Forward Compatibility Fix.  PUT responses now use 201 Created (under Cowboy) instead of 204 No Content (WebMachine - pre 3.7.0)


### PR DESCRIPTION
Newtonsoft.Json.JsonReaderException: JSON integer 2733561592 is too large or small for an Int32. Path '[6].memory', line 1, position 7110. 

Memory related types are changed to long.