### PR TITLE
Fixing bugs in .NET Core port

### DIFF
--- a/Source/EasyNetQ.Management.Client/HttpWebRequestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/HttpWebRequestExtensions.cs
@@ -5,20 +5,17 @@ namespace EasyNetQ.Management.Client
 {
     public static class HttpWebRequestExtensions
     {
-        public static HttpResponseMessage GetHttpResponse(this HttpRequestMessage request)
+        public static HttpResponseMessage GetHttpResponse(this HttpClient client, HttpRequestMessage request)
         {
-            return GetHttpResponseAsync(request).Result;
+            return GetHttpResponseAsync(client, request).Result;
         }
 
         /// <summary>
         /// https://blogs.msdn.microsoft.com/pfxteam/2012/04/13/should-i-expose-synchronous-wrappers-for-asynchronous-methods/
         /// </summary>
-        public static async Task<HttpResponseMessage> GetHttpResponseAsync(this HttpRequestMessage request)
+        public static async Task<HttpResponseMessage> GetHttpResponseAsync(this HttpClient client, HttpRequestMessage request)
         {
-            using (var client = new HttpClient())
-            {
-                return await client.SendAsync(request).ConfigureAwait(false);
-            }
+            return await client.SendAsync(request).ConfigureAwait(false);
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -122,6 +122,9 @@ namespace EasyNetQ.Management.Client
             };
 
             this.httpClient = new HttpClient(messageHandler) { Timeout = this.timeout };
+
+            //default WebRequest.KeepAlive to false to resolve spurious 'the request was aborted: the request was canceled' exceptions
+            httpClient.DefaultRequestHeaders.Add("Connection", "close");
         }
 
         public Overview GetOverview(GetLengthsCriteria lengthsCriteria = null, GetRatesCriteria ratesCriteria = null)
@@ -620,11 +623,6 @@ namespace EasyNetQ.Management.Client
         {
             var request = CreateRequestForPath(path, HttpMethod.Put);
 
-            if (!request.Headers.Accept.Contains(JsonMediaTypeHeaderValue))
-            {
-                request.Headers.Accept.Add(JsonMediaTypeHeaderValue);
-            }
-
             using (var response = httpClient.GetHttpResponse(request))
             {
                 // The "Cowboy" server in 3.7.0's Management Client returns 201 Created. 
@@ -672,8 +670,10 @@ namespace EasyNetQ.Management.Client
             }
 
             var body = JsonConvert.SerializeObject(item, Settings);
+            var content = new StringContent(body);
 
-            request.Content = new StringContent(body);
+            content.Headers.ContentType = JsonMediaTypeHeaderValue;
+            request.Content = content;
         }
 
         private T DeserializeResponse<T>(HttpResponseMessage response)

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -576,7 +576,7 @@ namespace EasyNetQ.Management.Client
         {
             var request = CreateRequestForPath(path, HttpMethod.Get, queryObjects);
 
-            using (var response = request.GetHttpResponse())
+            using (var response = httpClient.GetHttpResponse(request))
             {
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
@@ -592,7 +592,7 @@ namespace EasyNetQ.Management.Client
 
             InsertRequestBody(request, item);
 
-            using(var response = request.GetHttpResponse())
+            using(var response = httpClient.GetHttpResponse(request))
             {
                 if (!(response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.Created))
                 {
@@ -607,7 +607,7 @@ namespace EasyNetQ.Management.Client
         {
             var request = CreateRequestForPath(path, HttpMethod.Delete);
 
-            using (var response = request.GetHttpResponse())
+            using (var response = httpClient.GetHttpResponse(request))
             {
                 if (response.StatusCode != HttpStatusCode.NoContent)
                 {
@@ -625,7 +625,7 @@ namespace EasyNetQ.Management.Client
                 request.Headers.Accept.Add(JsonMediaTypeHeaderValue);
             }
 
-            using (var response = request.GetHttpResponse())
+            using (var response = httpClient.GetHttpResponse(request))
             {
                 // The "Cowboy" server in 3.7.0's Management Client returns 201 Created. 
                 // "MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)" in 3.6.1 and previous return 204 No Content
@@ -646,7 +646,7 @@ namespace EasyNetQ.Management.Client
 
             InsertRequestBody(request, item);
 
-            using (var response = request.GetHttpResponse())
+            using (var response = httpClient.GetHttpResponse(request))
             {
                 // The "Cowboy" server in 3.7.0's Management Client returns 201 Created. 
                 // "MochiWeb/1.1 WebMachine/1.10.0 (never breaks eye contact)" in 3.6.1 and previous return 204 No Content


### PR DESCRIPTION
While running the integration tests, I noticed a few issues that are fixed here:

* Not sending HTTP requests with credentials
* Not setting the Content-Type when there is a content body
* Mitigating "connection aborted" exceptions when running tests by adding back the equivalent of `WebRequest.KeepAlive = false` that was there before