### PR TITLE
Migrating tests to xUnit

### DIFF
--- a/Build/EasyNetQ.proj
+++ b/Build/EasyNetQ.proj
@@ -42,11 +42,18 @@
         <MSBuild Projects="@(ProjectToBuild)" Targets="Clean;Rebuild"/>
     </Target>
 
+    <!-- Running xUnit tests using dotnet test. Running tests that are not
+        Integration tests. Continuing on error so that all of the test binaries
+        can run. This allows us to see all of the test results in AppVeyor if
+        there are multiple test suites failing. -->
     <Target Name="Test" DependsOnTargets="Build">
         <ItemGroup>
-            <TestAssembly Include="$(OutputDir)\**\net451\*.Tests.dll" />
+            <TestProjects Include="$(Source)\*Tests\project.json" />
         </ItemGroup>
-        <NUnit ToolPath="$(Nunit)" DisableShadowCopy="true" Assemblies="@(TestAssembly)" Framework="4.0.30319" Force32Bit="true" />
+
+        <Exec WorkingDirectory="%(TestProjects.RootDir)\%(TestProjects.Directory)"
+              Command='dotnet test -notrait "Category=Integration"'
+              ContinueOnError="ErrorAndContinue" />
     </Target>
 
     <Target Name="MergeManagementClient" DependsOnTargets="Test">

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/EasyNetQTestException.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/EasyNetQTestException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Exception thrown when something unexpected happens in tests
+    /// </summary>
+    public class EasyNetQTestException : Exception
+    {
+        public EasyNetQTestException(string message)
+            : base(message)
+        { }
+
+        public EasyNetQTestException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientMonoTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientMonoTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {
@@ -12,7 +12,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         private const string password = "guest";
         private const int port = 15672;
 
-        [Test]
+        [Fact]
         public void Should_get_overview_on_mono()
         {
             var managementClient2 = new ManagementClient(hostUrl, username, password, port, true);
@@ -37,7 +37,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-		[Test]
+		[Fact]
 		public void Should_get_vHost_OK()
 		{
 			var client = new ManagementClient (hostUrl, username, password, port, true);
@@ -47,7 +47,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 			Console.WriteLine ("Got vHost with name '{0}'.", vHost.Name);
 		}
 
-		[Test]
+		[Fact]
 		public void Should_get_queue_OK()
 		{
 			var client = new ManagementClient (hostUrl, username, password, port, true);
@@ -55,7 +55,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 			Console.WriteLine ("Got queue: {0}", queue.Name);
 		}
 
-		[Test]
+		[Fact]
 		public void Should_get_Channel_OK()
 		{
             var managementClient2 = new ManagementClient(hostUrl, username, password, port, true);

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientMonoTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientMonoTests.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using EasyNetQ.Management.Client.Tests;
+using System;
 using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {
-    [TestFixture(Category = "Integration")]
+    [Integration]
     [Explicit("Requires a broker on localhost, and to be running on the Mono CLR")]
     public class ManagementClientMonoTests
     {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -184,7 +184,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
-                throw new ApplicationException(
+                throw new EasyNetQTestException(
                     string.Format("Test exchange '{0}' hasn't been created", testExchange));
             }
 
@@ -197,7 +197,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchangetestQueueWithPlusChar);
             if (exchange == null)
             {
-                throw new ApplicationException(
+                throw new EasyNetQTestException(
                     string.Format("Test exchange '{0}' hasn't been created", testExchange));
             }
 
@@ -210,7 +210,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
-                throw new ApplicationException(
+                throw new EasyNetQTestException(
                     string.Format("Test exchange '{0}' hasn't been created", testExchange));
             }
 
@@ -228,7 +228,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
-                throw new ApplicationException(
+                throw new EasyNetQTestException(
                     string.Format("Test exchange '{0}' hasn't been created", testExchange));
             }
 
@@ -246,7 +246,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
             if (exchange == null)
             {
-                throw new ApplicationException(
+                throw new EasyNetQTestException(
                     string.Format("Test exchange '{0}' hasn't been created", testExchange));
             }
 
@@ -366,7 +366,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
-                throw new ApplicationException("Test queue has not been created");
+                throw new EasyNetQTestException("Test queue has not been created");
             }
 
             managementClient.DeleteQueue(queue);
@@ -378,7 +378,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
-                throw new ApplicationException("Test queue has not been created");
+                throw new EasyNetQTestException("Test queue has not been created");
             }
 
             var bindings = managementClient.GetBindingsForQueue(queue);
@@ -395,7 +395,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
-                throw new ApplicationException("Test queue has not been created");
+                throw new EasyNetQTestException("Test queue has not been created");
             }
 
             managementClient.Purge(queue);
@@ -407,7 +407,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
             if (queue == null)
             {
-                throw new ApplicationException("Test queue has not been created");
+                throw new EasyNetQTestException("Test queue has not been created");
             }
 
             var defaultExchange = new Exchange { Name = "amq.default", Vhost = vhostName };
@@ -656,12 +656,12 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var user = managementClient.GetUsers().SingleOrDefault(x => x.Name == testUser);
             if (user == null)
             {
-                throw new ApplicationException(string.Format("user '{0}' hasn't been created", testUser));
+                throw new EasyNetQTestException(string.Format("user '{0}' hasn't been created", testUser));
             }
             var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == testVHost);
             if (vhost == null)
             {
-                throw new ApplicationException(string.Format("Test vhost: '{0}' has not been created", testVHost));
+                throw new EasyNetQTestException(string.Format("Test vhost: '{0}' has not been created", testVHost));
             }
 
             var permissionInfo = new PermissionInfo(user, vhost);
@@ -681,7 +681,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == vhostName);
             if (vhost == null)
             {
-                throw new ApplicationException(string.Format("Default vhost: '{0}' has not been created", testVHost));
+                throw new EasyNetQTestException(string.Format("Default vhost: '{0}' has not been created", testVHost));
 
             }
 
@@ -697,7 +697,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
             if (permission == null)
             {
-                throw new ApplicationException(string.Format("No permission for vhost: {0} and user: {1}",
+                throw new EasyNetQTestException(string.Format("No permission for vhost: {0} and user: {1}",
                     testVHost, testUser));
             }
 
@@ -723,7 +723,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == testVHost);
             if (vhost == null)
             {
-                throw new ApplicationException(string.Format("Test vhost: '{0}' has not been created", testVHost));
+                throw new EasyNetQTestException(string.Format("Test vhost: '{0}' has not been created", testVHost));
             }
             managementClient.IsAlive(vhost).ShouldBeTrue();
         }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1,15 +1,16 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using EasyNetQ.Management.Client.Model;
-using Xunit;
+using EasyNetQ.Management.Client.Tests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {
-    [TestFixture(Category = "Integration")]
-    [Explicit ("requires a rabbitMQ instance on localhost to run")]
+    [Integration]
+    [Explicit("requires a rabbitMQ instance on localhost to run")]
     public class ManagementClientTests
     {
         private readonly IManagementClient managementClient;

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -538,9 +538,9 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.DeleteExchange(sourceExchange);
             managementClient.DeleteExchange(destinationExchange);
 
-            Assert.AreEqual("exchange", binding.DestinationType);
-            Assert.AreEqual(destinationExchangeName, binding.Destination);
-            Assert.AreEqual("#", binding.RoutingKey);
+            Assert.Equal("exchange", binding.DestinationType);
+            Assert.Equal(destinationExchangeName, binding.Destination);
+            Assert.Equal("#", binding.RoutingKey);
         }
 
         [Fact]
@@ -732,7 +732,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         public void Should_be_able_to_get_policies_list()
         {
             var policies = managementClient.GetPolicies();
-            Assert.IsNotNull(policies);
+            Assert.NotNull(policies);
         }
 
         [Fact]
@@ -752,7 +752,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     HaSyncMode = haSyncMode
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.ApplyTo == ApplyMode.All
@@ -778,7 +778,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     HaSyncMode = haSyncMode
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.ApplyTo == ApplyMode.Queues
@@ -804,7 +804,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     HaSyncMode = haSyncMode
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.ApplyTo == ApplyMode.Exchanges
@@ -827,7 +827,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     AlternateExchange = alternateExchange
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.AlternateExchange == alternateExchange));
@@ -850,7 +850,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     DeadLetterRoutingKey = deadLetterRoutingKey
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.DeadLetterExchange == deadLetterExchange
@@ -872,7 +872,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     MessageTtl = messageTtl
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.MessageTtl == messageTtl));
@@ -893,7 +893,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     Expires = expires
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.Expires == expires));
@@ -914,7 +914,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     MaxLength = maxLength
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.MaxLength == maxLength));
@@ -951,7 +951,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                 },
                 Priority = priority
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Priority == priority
@@ -982,7 +982,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     FederationUpstream = "my-upstream"
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.FederationUpstream == "my-upstream"));
@@ -1004,7 +1004,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     FederationUpstreamSet = "my-upstream-set"
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(
+            Assert.Equal(1, managementClient.GetPolicies().Count(
                 p => p.Name == policyName
                      && p.Vhost == vhostName
                      && p.Definition.FederationUpstreamSet == "my-upstream-set"));
@@ -1025,9 +1025,9 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     HaSyncMode = HaSyncMode.Automatic
                 }
             });
-            Assert.AreEqual(1, managementClient.GetPolicies().Count(p => p.Name == policyName && p.Vhost == vhostName));
+            Assert.Equal(1, managementClient.GetPolicies().Count(p => p.Name == policyName && p.Vhost == vhostName));
             managementClient.DeletePolicy(policyName, new Vhost{Name = vhostName});
-            Assert.AreEqual(0, managementClient.GetPolicies().Count(p => p.Name == policyName && p.Vhost == vhostName));
+            Assert.Equal(0, managementClient.GetPolicies().Count(p => p.Name == policyName && p.Vhost == vhostName));
         }
 
         [Fact]
@@ -1037,8 +1037,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             Assert.NotNull(parameters);
         }
 
-        [Fact]
-        [Ignore("Requires the federation plugin to work")]
+        [Fact(Skip = "Requires the federation plugin to work")]
         public void Should_be_able_to_create_parameter()
         {
             try

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1,7 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,7 +31,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient = new ManagementClient(hostUrl, username, password);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_configure_request()
         {
             var client = new ManagementClient(hostUrl, username, password, configureRequest: 
@@ -40,7 +40,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             client.GetOverview();
         }
 
-        [Test]
+        [Fact]
         public void Should_get_overview()
         {
             var overview = managementClient.GetOverview();
@@ -63,7 +63,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_get_nodes()
         {
             var nodes = managementClient.GetNodes();
@@ -72,7 +72,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             nodes.First().Name.ShouldEqual("rabbit@" + Environment.MachineName);
         }
 
-        [Test]
+        [Fact]
         public void Should_get_definitions()
         {
             var definitions = managementClient.GetDefinitions();
@@ -80,7 +80,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             definitions.RabbitVersion[0].ShouldEqual('3');
         }
 
-        [Test]
+        [Fact]
         public void Should_get_connections()
         {
             var connections = managementClient.GetConnections();
@@ -104,7 +104,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_close_connection()
         {
             // first get a connection
@@ -121,7 +121,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.CloseConnection(connection);
         }
 
-        [Test]
+        [Fact]
         public void Should_get_channels()
         {
             var channels = managementClient.GetChannels();
@@ -134,7 +134,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_get_exchanges()
         {
             var exchanges = managementClient.GetExchanges();
@@ -145,7 +145,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_an_individual_exchange_by_name()
         {
             var vhost = new Vhost { Name = vhostName };
@@ -154,7 +154,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             exchange.Name.ShouldEqual(testExchange);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_an_exchange()
         {
             var exchange = CreateExchange(testExchange);
@@ -169,7 +169,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             return exchange;
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_an_exchange_with_plus_char_in_the_name()
         {
             var vhost = managementClient.GetVhost(vhostName);
@@ -178,7 +178,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Name.ShouldEqual(testExchangetestQueueWithPlusChar);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_an_exchange()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
@@ -191,7 +191,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.DeleteExchange(exchange);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_an_exchange_with_pluses()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchangetestQueueWithPlusChar);
@@ -204,7 +204,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.DeleteExchange(exchange);
         }
 
-        [Test]
+        [Fact]
         public void Should_get_all_bindings_for_which_the_exchange_is_the_source()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
@@ -222,7 +222,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_get_all_bindings_for_which_the_exchange_is_the_destination()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
@@ -240,7 +240,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_publish_to_an_exchange()
         {
             var exchange = managementClient.GetExchanges().SingleOrDefault(x => x.Name == testExchange);
@@ -257,7 +257,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             result.Routed.ShouldBeFalse();
         }
 
-        [Test]
+        [Fact]
         public void Should_get_queues()
         {
             var queues = managementClient.GetQueues();
@@ -268,7 +268,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_queue_by_name()
         {
             var vhost = new Vhost { Name = vhostName };
@@ -276,7 +276,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Name.ShouldEqual(testQueue);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_queue_by_name_with_plus_char()
         {
             var vhost = new Vhost { Name = vhostName };
@@ -284,7 +284,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Name.ShouldEqual(testQueueWithPlusChar);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_queue_by_name_with_detailed_length_information()
         {
             var age = 60;
@@ -297,7 +297,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.MessagesUnacknowledgedDetails.Samples.Count.ShouldEqual(7);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_queue_by_name_with_detailed_rates_information()
         {
             var age = 60;
@@ -311,7 +311,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             //queue.MessageStats.PublishDetails.Samples.Count.ShouldEqual(7);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_queue_by_name_with_all_detailed_information()
         {
             var age = 60;
@@ -328,7 +328,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             //queue.MessageStats.PublishDetails.Samples.Count.ShouldEqual(7);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_a_queue()
         {
             var vhost = managementClient.GetVhost(vhostName);
@@ -338,7 +338,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Name.ShouldEqual(testQueue);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_a_queue_with_plus_char_in_the_name()
         {
             var vhost = managementClient.GetVhost(vhostName);
@@ -347,7 +347,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Name.ShouldEqual(testQueueWithPlusChar);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_a_queue_with_arguments()
         {
             var exchangeName = "test-dead-letter-exchange";
@@ -360,7 +360,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             queue.Arguments[argumentKey].ShouldEqual(exchangeName);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_a_queue()
         {
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
@@ -372,7 +372,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.DeleteQueue(queue);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_all_the_bindings_for_a_queue()
         {
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
@@ -389,7 +389,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_purge_a_queue()
         {
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
@@ -401,7 +401,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.Purge(queue);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_messages_from_a_queue()
         {
             var queue = managementClient.GetQueues().SingleOrDefault(x => x.Name == testQueue);
@@ -434,7 +434,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_get_bindings()
         {
             var bindings = managementClient.GetBindings();
@@ -447,7 +447,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_list_of_bindings_between_an_exchange_and_a_queue()
         {
             var queue = EnsureQueueExists(testQueue);
@@ -481,7 +481,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             return managementClient.GetQueue(queueName, vhost);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_list_of_bindings_between_an_exchange_and_an_exchange()
         {
             var exchange1 = EnsureExchangeExists(testExchange);
@@ -506,7 +506,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                     ?? CreateExchange(exchangeName);
         }
 
-        [Test]
+        [Fact]
         public void Should_create_binding()
         {
             var vhost = managementClient.GetVhost(vhostName);
@@ -518,7 +518,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.CreateBinding(exchange, queue, bindingInfo);
         }
 
-        [Test]
+        [Fact]
         public void Should_create_exchange_to_exchange_binding()
         {
             const string sourceExchangeName = "management_api_test_source_exchange";
@@ -543,7 +543,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             Assert.AreEqual("#", binding.RoutingKey);
         }
 
-        [Test]
+        [Fact]
         public void Should_delete_binding()
         {
             var vhost = managementClient.GetVhost(vhostName);
@@ -558,7 +558,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_get_vhosts()
         {
             var vhosts = managementClient.GetVHosts();
@@ -571,28 +571,28 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
         private const string testVHost = "management_test_virtual_host";
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_an_individual_vhost()
         {
             var vhost = managementClient.GetVhost(testVHost);
             vhost.Name.ShouldEqual(testVHost);
         }
 
-        [Test]
+        [Fact]
         public void Should_create_a_virtual_host()
         {
             var vhost = managementClient.CreateVirtualHost(testVHost);
             vhost.Name.ShouldEqual(testVHost);
         }
 
-        [Test]
+        [Fact]
         public void Should_delete_a_virtual_host()
         {
             var vhost = managementClient.GetVhost(testVHost);
             managementClient.DeleteVirtualHost(vhost);
         }
 
-        [Test]
+        [Fact]
         public void Should_get_users()
         {
             var users = managementClient.GetUsers();
@@ -603,14 +603,14 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_a_user_by_name()
         {
             var user = managementClient.GetUser(testUser);
             user.Name.ShouldEqual(testUser);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_a_user()
         {
             var userInfo = new UserInfo(testUser, "topSecret").AddTag("administrator");
@@ -619,7 +619,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             user.Name.ShouldEqual(testUser);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_a_user_with_the_policymaker_tag()
         {
             var userInfo = new UserInfo(testUser, "topSecret").AddTag("policymaker");
@@ -628,14 +628,14 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             user.Name.ShouldEqual(testUser);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_a_user()
         {
             var user = managementClient.GetUser(testUser);
             managementClient.DeleteUser(user);
         }
 
-        [Test]
+        [Fact]
         public void Should_get_permissions()
         {
             var permissions = managementClient.GetPermissions();
@@ -650,7 +650,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_permissions()
         {
             var user = managementClient.GetUsers().SingleOrDefault(x => x.Name == testUser);
@@ -668,7 +668,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.CreatePermission(permissionInfo);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_permissions_in_default_Vhost()
         {
             var user = managementClient.GetUsers().SingleOrDefault(x => x.Name == testUser);
@@ -689,7 +689,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.CreatePermission(permissionInfo);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_permissions()
         {
             var permission = managementClient.GetPermissions()
@@ -704,7 +704,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.DeletePermission(permission);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_change_the_password_of_a_user()
         {
             var userInfo = new UserInfo(testUser, "topSecret").AddTag("monitoring").AddTag("management");
@@ -717,7 +717,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             updatedUser.PasswordHash.ShouldNotEqual(user.PasswordHash);
         }
 
-        [Test]
+        [Fact]
         public void Should_check_that_the_broker_is_alive()
         {
             var vhost = managementClient.GetVHosts().SingleOrDefault(x => x.Name == testVHost);
@@ -728,14 +728,14 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.IsAlive(vhost).ShouldBeTrue();
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_policies_list()
         {
             var policies = managementClient.GetPolicies();
             Assert.IsNotNull(policies);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_policies()
         {
             var policyName = "asamplepolicy";
@@ -760,7 +760,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.HaSyncMode == haSyncMode));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_queues_only_policies()
         {
             var policyName = "asamplepolicy-queue-only";
@@ -786,7 +786,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.HaSyncMode == haSyncMode));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_exchanges_only_policies()
         {
             var policyName = "asamplepolicy-exchange-only";
@@ -812,7 +812,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.HaSyncMode == haSyncMode));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_alternate_exchange_policy()
         {
             var policyName = "a-sample-alternate-exchange-policy";
@@ -833,7 +833,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.AlternateExchange == alternateExchange));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_dead_letter_exchange_policy()
         {
             var policyName = "a-sample-dead-letter-exchange";
@@ -857,7 +857,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.DeadLetterRoutingKey == deadLetterRoutingKey));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_message_ttl_policy()
         {
             var policyName = "a-sample-message-ttl";
@@ -878,7 +878,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.MessageTtl == messageTtl));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_expires_policy()
         {
             var policyName = "a-sample-expires";
@@ -899,7 +899,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.Expires == expires));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_max_length_policy()
         {
             var policyName = "a-sample-max-length";
@@ -920,7 +920,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.MaxLength == maxLength));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_create_all_the_defitions_in_a_policy()
         {
             var policyName = "a-sample-all-definitions-in-a-policy";
@@ -966,7 +966,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         }
 
 
-        [Test]
+        [Fact]
         [Explicit]
         public void Should_be_able_to_create_federation_upstream_policy()
         {
@@ -988,7 +988,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.FederationUpstream == "my-upstream"));
         }
 
-        [Test]
+        [Fact]
         [Explicit]
         public void Should_be_able_to_create_federation_upstream_set_policy()
         {
@@ -1010,7 +1010,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                      && p.Definition.FederationUpstreamSet == "my-upstream-set"));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_delete_policies()
         {
             var policyName = "asamplepolicy";
@@ -1030,14 +1030,14 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             Assert.AreEqual(0, managementClient.GetPolicies().Count(p => p.Name == policyName && p.Vhost == vhostName));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_list_parameters()
         {
             var parameters = managementClient.GetParameters();
             Assert.NotNull(parameters);
         }
 
-        [Test]
+        [Fact]
         [Ignore("Requires the federation plugin to work")]
         public void Should_be_able_to_create_parameter()
         {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -12,7 +12,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
     [Explicit ("requires a rabbitMQ instance on localhost to run")]
     public class ManagementClientTests
     {
-        private IManagementClient managementClient;
+        private readonly IManagementClient managementClient;
 
         private const string hostUrl = "http://localhost";
         private const string username = "guest";
@@ -25,8 +25,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         private const string testQueueWithPlusChar = "management_api_test_queue+plus+test";
         private const string testUser = "mikey";
 
-        [SetUp]
-        public void SetUp()
+        public ManagementClientTests()
         {
             managementClient = new ManagementClient(hostUrl, username, password);
         }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -114,11 +114,11 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             managementClient.CloseConnection(connections.First());
         }
 
-        [Test, ExpectedException(typeof(UnexpectedHttpStatusCodeException))]
+        [Fact]
         public void Should_throw_when_trying_to_close_unknown_connection()
         {
             var connection = new Connection {Name = "unknown"};
-            managementClient.CloseConnection(connection);
+            Assert.Throws<UnexpectedHttpStatusCodeException>(() => managementClient.CloseConnection(connection));
         }
 
         [Fact]

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
@@ -1,12 +1,13 @@
 ﻿// ReSharper disable InconsistentNaming
 
-using System;
 using EasyNetQ.Management.Client.Model;
+using EasyNetQ.Management.Client.Tests;
+using System;
 using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {
-    [TestFixture(Category = "Integration")]
+    [Integration]
     [Explicit("Requires a RabbitMQ server on localhost to work")]
     public class ScenarioTest
     {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
@@ -2,7 +2,7 @@
 
 using System;
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {
@@ -10,16 +10,11 @@ namespace EasyNetQ.Management.Client.IntegrationTests
     [Explicit("Requires a RabbitMQ server on localhost to work")]
     public class ScenarioTest
     {
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
         /// <summary>
         /// Demonstrate how to create a virtual host, add some users, set permissions
         /// and create exchanges, queues and bindings.
         /// </summary>
-        [Test]
+        [Fact]
         public void Should_be_able_to_provision_a_virtual_host()
         {
             var initial = new ManagementClient("http://localhost", "guest", "guest");

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Linq;
-using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
 {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Xunit;
 
 namespace EasyNetQ.Management.Client.IntegrationTests
@@ -13,12 +12,6 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             return obj;
         }
 
-        public static T ShouldNotBeNull<T>(this T obj, string message)
-        {
-            Assert.NotNull(obj, message);
-            return obj;
-        }
-
         public static T ShouldEqual<T>(this T actual, object expected)
         {
             Assert.Equal(expected, actual);
@@ -28,12 +21,6 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         public static T ShouldNotEqual<T>(this T actual, object expected)
         {
             Assert.NotEqual(expected, actual);
-            return actual;
-        }
-
-        public static T ShouldEqual<T>(this T actual, object expected, string message)
-        {
-            Assert.Equal(expected, actual, message);
             return actual;
         }
 

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/TestExtensions.cs
@@ -9,53 +9,52 @@ namespace EasyNetQ.Management.Client.IntegrationTests
     {
         public static T ShouldNotBeNull<T>(this T obj)
         {
-            Assert.IsNotNull(obj);
+            Assert.NotNull(obj);
             return obj;
         }
 
         public static T ShouldNotBeNull<T>(this T obj, string message)
         {
-            Assert.IsNotNull(obj, message);
+            Assert.NotNull(obj, message);
             return obj;
         }
 
         public static T ShouldEqual<T>(this T actual, object expected)
         {
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
             return actual;
         }
 
         public static T ShouldNotEqual<T>(this T actual, object expected)
         {
-            Assert.AreNotEqual(expected, actual);
+            Assert.NotEqual(expected, actual);
             return actual;
         }
-
 
         public static T ShouldEqual<T>(this T actual, object expected, string message)
         {
-            Assert.AreEqual(expected, actual, message);
+            Assert.Equal(expected, actual, message);
             return actual;
         }
 
-        public static Exception ShouldBeThrownBy(this Type exceptionType, TestDelegate testDelegate)
+        public static Exception ShouldBeThrownBy(this Type exceptionType, Action testDelegate)
         {
             return Assert.Throws(exceptionType, testDelegate);
         }
 
         public static void ShouldBe<T>(this object actual)
         {
-            Assert.IsInstanceOf<T>(actual);
+            Assert.IsType<T>(actual);
         }
 
         public static void ShouldBeNull(this object actual)
         {
-            Assert.IsNull(actual);
+            Assert.Null(actual);
         }
 
         public static void ShouldBeTheSameAs(this object actual, object expected)
         {
-            Assert.AreSame(expected, actual);
+            Assert.Same(expected, actual);
         }
 
         public static T CastTo<T>(this object source)
@@ -65,28 +64,27 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
         public static void ShouldBeTrue(this bool source)
         {
-            Assert.IsTrue(source);
+            Assert.True(source);
         }
 
         public static void ShouldBeTrue(this bool source, string message)
         {
-            Assert.IsTrue(source, message);
+            Assert.True(source, message);
         }
 
         public static void ShouldBeFalse(this bool source)
         {
-            Assert.IsFalse(source);
+            Assert.False(source);
         }
 
         public static void ShouldBeFalse(this bool source, string message)
         {
-            Assert.IsFalse(source, message);
+            Assert.False(source, message);
         }
 
         public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
         {
-            Assert.AreEqual(collection.Count(), 0,
-            string.Format("Expected collection to be empty, but had {0} items", collection.Count()));
+            Assert.Empty(collection);
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/Category.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/Category.cs
@@ -1,0 +1,12 @@
+﻿namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Possible test categories
+    /// </summary>
+    public enum Category
+    {
+        None,
+        Integration,
+        Explicit
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/CategoryAttribute.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/CategoryAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Apply this attribute to your test method to specify a category.
+    /// </summary>
+    /// <remarks>
+    /// From xUnit sample about Trait extensibility:
+    /// https://github.com/xunit/samples.xunit/blob/master/TraitExtensibility/CategoryAttribute.cs
+    /// </remarks>
+    [TraitDiscoverer("EasyNetQ.Management.Client.Tests.CategoryDiscoverer", "EasyNetQ.Management.Client.IntegrationTests")]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public class CategoryAttribute : Attribute, ITraitAttribute
+    {
+        public CategoryAttribute(Category category)
+        {
+            Category = category;
+        }
+
+        public Category Category { get; set; }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/CategoryDiscoverer.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/CategoryDiscoverer.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Adapted from xUnit sample on Trait extensibility
+    /// https://github.com/xunit/samples.xunit/blob/master/TraitExtensibility/CategoryDiscoverer.cs
+    /// </summary>
+    public class CategoryDiscoverer : ITraitDiscoverer
+    {
+        public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+        {
+            var namedArgs = traitAttribute.GetNamedArgument<Category>(nameof(CategoryAttribute.Category));
+
+            if (namedArgs == Category.None)
+            {
+                yield break;
+            }
+            else
+            {
+                yield return new KeyValuePair<string, string>("Category", namedArgs.ToString());
+            }
+        }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/ExplicitAttribute.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/ExplicitAttribute.cs
@@ -1,0 +1,21 @@
+﻿namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Category specifiying that a test has to be explicitly named before it
+    /// is run.
+    /// </summary>
+    public class ExplicitAttribute : CategoryAttribute
+    {
+        public ExplicitAttribute()
+            : base(Category.Explicit)
+        { }
+
+        public ExplicitAttribute(string skipReason)
+            : base(Category.Explicit)
+        {
+            SkipReason = skipReason;
+        }
+
+        public string SkipReason { get; set; }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/IntegrationAttribute.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/IntegrationAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Category specifiying that the following test is an integration test.
+    /// </summary>
+    public class IntegrationAttribute : CategoryAttribute
+    {
+        public IntegrationAttribute()
+            : base(Category.Integration)
+        { }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "NUnit": "2.6.4"
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "buildOptions": {
     "compile": {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
@@ -3,7 +3,9 @@
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta2-build3300",
+    "xunit.core": "2.2.0-beta2-build3300",
+    "xunit.runner.visualstudio": "2.2.0-beta2-build1149"
   },
   "testRunner": "xunit",
   "buildOptions": {
@@ -12,12 +14,6 @@
     }
   },
   "frameworks": {
-    "net451": {
-      "frameworkAssemblies": {
-        "Microsoft.CSharp": "4.0.0.0",
-        "System.Net.Http": "4.0.0.0"
-      }
-    },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -28,6 +24,7 @@
     }
   },
   "runtimes": {
-    "win": {}
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/project.json
@@ -1,10 +1,11 @@
 ﻿{
   "dependencies": {
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "xunit": "2.2.0-beta2-build3300"
   },
+  "testRunner": "xunit",
   "buildOptions": {
     "compile": {
       "includeFiles": "..\\Version.cs"
@@ -15,6 +16,14 @@
       "frameworkAssemblies": {
         "Microsoft.CSharp": "4.0.0.0",
         "System.Net.Http": "4.0.0.0"
+      }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
       }
     }
   },

--- a/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.xproj
+++ b/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{F411090D-1CAB-4726-9F2B-582E9D9D80D7}</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Source/EasyNetQ.Management.Client.Tests/EasyNetQTestException.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/EasyNetQTestException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace EasyNetQ.Management.Client.Tests
+{
+    /// <summary>
+    /// Exception thrown when something unexpected happens in tests
+    /// </summary>
+    public class EasyNetQTestException : Exception
+    {
+        public EasyNetQTestException(string message)
+            : base(message)
+        { }
+
+        public EasyNetQTestException(string message, Exception innerException)
+            : base(message, innerException)
+        { }
+    }
+}

--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientInternalsTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientInternalsTests.cs
@@ -45,15 +45,15 @@ namespace EasyNetQ.Management.Client.Tests
 
             var channels = JsonConvert.DeserializeObject<IEnumerable<Channel>>(responseBody, settings).ToList();
 
-            Assert.AreEqual(2,channels.Count);
+            Assert.Equal(2,channels.Count);
 
-            Assert.AreEqual(48538, channels[0].MessageStats.DeliverGet);
-            Assert.AreEqual(48538, channels[0].MessageStats.DeliverNoAck);
-            Assert.AreEqual(0, channels[0].MessageStats.Publish);
+            Assert.Equal(48538, channels[0].MessageStats.DeliverGet);
+            Assert.Equal(48538, channels[0].MessageStats.DeliverNoAck);
+            Assert.Equal(0, channels[0].MessageStats.Publish);
 
-            Assert.AreEqual(0, channels[1].MessageStats.DeliverGet);
-            Assert.AreEqual(0, channels[1].MessageStats.DeliverNoAck);
-            Assert.AreEqual(48538, channels[1].MessageStats.Publish);
+            Assert.Equal(0, channels[1].MessageStats.DeliverGet);
+            Assert.Equal(0, channels[1].MessageStats.DeliverNoAck);
+            Assert.Equal(48538, channels[1].MessageStats.Publish);
 
         }
 

--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientInternalsTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientInternalsTests.cs
@@ -1,21 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using EasyNetQ.Management.Client.Model;
 using EasyNetQ.Management.Client.Serialization;
-using NUnit.Framework;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests
 {
-    [TestFixture(Category = "Unit")]
     public class ManagementClientInternalsTests
     {
         /// <summary>
         /// Checks for regression from using Int32 instead of Int64 for RecvOct and so on
         /// </summary>
-        [Test]
+        [Fact]
         public void GetConnections_CheckDeserializeLargeNumbers()
         {
             //TODO: redesign the ManagementClient by factoring out some of it's responsibilities and use dependency injection
@@ -33,7 +31,7 @@ namespace EasyNetQ.Management.Client.Tests
             var connections = JsonConvert.DeserializeObject<IEnumerable<Connection>>(responseBody, settings);
         }
 
-        [Test]
+        [Fact]
         public void GetChannels()
         {
             JsonSerializerSettings settings = new JsonSerializerSettings

--- a/Source/EasyNetQ.Management.Client.Tests/Model/ExchangeInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/ExchangeInfoTests.cs
@@ -1,18 +1,12 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class ExchangeInfoTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
         [Fact]
         public void Should_be_able_to_get_name()
         {
@@ -21,10 +15,10 @@ namespace EasyNetQ.Management.Client.Tests.Model
             exchangeInfo.GetName().ShouldEqual(expectedName);
         }
 
-        [Test, ExpectedException(typeof(EasyNetQManagementException))]
+        [Fact]
         public void Should_throw_if_we_try_to_create_an_exchange_with_an_unknown_type()
         {
-            new ExchangeInfo("management_api_test_exchange", "some_bullshit_exchange_type");
+            Assert.Throws<EasyNetQManagementException>(() => new ExchangeInfo("management_api_test_exchange", "some_bullshit_exchange_type"));
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/ExchangeInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/ExchangeInfoTests.cs
@@ -13,7 +13,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
         {
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_get_name()
         {
             const string expectedName = "the_name";

--- a/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
         {
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_deserialize_message_with_properties()
         {
             const string json = @"{""payload_bytes"":11,""redelivered"":true,""exchange"":""""," + 
@@ -31,7 +31,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             message.Properties.Headers["key"].ShouldEqual("value");
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_deserialize_message_without_properties()
         {
             const string json = @"{""payload_bytes"":11,""redelivered"":true,""exchange"":""""," +

--- a/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/MessageSerializationTests.cs
@@ -2,19 +2,13 @@
 
 using EasyNetQ.Management.Client.Model;
 using EasyNetQ.Management.Client.Serialization;
-using NUnit.Framework;
 using Newtonsoft.Json;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class MessageSerializationTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
         [Fact]
         public void Should_be_able_to_deserialize_message_with_properties()
         {

--- a/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
@@ -17,13 +17,13 @@ namespace EasyNetQ.Management.Client.Tests.Model
             nodes = ResourceLoader.LoadObjectFromJson<List<Node>>("Nodes.json");
         }
 
-        [Test]
+        [Fact]
         public void Should_load_one_node()
         {
             nodes.Count.ShouldEqual(1);
         }
 
-        [Test]
+        [Fact]
         public void Should_have_node_properties()
         {
             var node = nodes[0];

--- a/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/NodeSerializationTests.cs
@@ -6,13 +6,11 @@ using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class NodeSerializationTests
     {
-        private List<Node> nodes;
+        private readonly List<Node> nodes;
 
-        [SetUp]
-        public void SetUp()
+        public NodeSerializationTests()
         {
             nodes = ResourceLoader.LoadObjectFromJson<List<Node>>("Nodes.json");
         }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
@@ -1,7 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
@@ -16,14 +16,14 @@ namespace EasyNetQ.Management.Client.Tests.Model
             overview = ResourceLoader.LoadObjectFromJson<Overview>("Overview.json", ManagementClient.Settings);
         }
 
-        [Test]
+        [Fact]
         public void Should_contain_management_version()
         {
             overview.ManagementVersion.ShouldEqual("2.8.6");
             overview.StatisticsLevel.ShouldEqual("fine");
         }
 
-        [Test]
+        [Fact]
         public void Should_congtain_exchange_types()
         {
             overview.ExchangeTypes[0].Name.ShouldEqual("topic");

--- a/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
@@ -5,13 +5,11 @@ using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class OverviewSerializationTests
     {
-        private Overview overview;
+        private readonly Overview overview;
 
-        [SetUp]
-        public void SetUp()
+        public OverviewSerializationTests()
         {
             overview = ResourceLoader.LoadObjectFromJson<Overview>("Overview.json", ManagementClient.Settings);
         }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/ParameterSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/ParameterSerializationTests.cs
@@ -3,12 +3,11 @@
     using Client.Model;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using NUnit.Framework;
+    using Xunit;
 
-    [TestFixture(Category = "Unit")]
     public class ParameterSerializationTests
     {
-        [Test]
+        [Fact]
         public void Should_be_able_to_serialize_arbitrary_object_as_value()
         {
             var serializedvalue =

--- a/Source/EasyNetQ.Management.Client.Tests/Model/ParameterSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/ParameterSerializationTests.cs
@@ -19,7 +19,7 @@
                     Value = new Policy {Pattern = "testvalue"}
                 }, ManagementClient.Settings);
             var parsedValue = JObject.Parse(serializedvalue);
-            Assert.AreEqual("testvalue", parsedValue["value"]["pattern"].Value<string>());
+            Assert.Equal("testvalue", parsedValue["value"]["pattern"].Value<string>());
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
@@ -5,15 +5,13 @@ using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class PermissionInfoTests
     {
         private PermissionInfo permissionInfo;
         private User user;
         private Vhost vhost;
 
-        [SetUp]
-        public void SetUp()
+        public PermissionInfoTests()
         {
             user = new User { Name = "mikey" };
             vhost = new Vhost { Name = "theVHostName" };

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PermissionInfoTests.cs
@@ -1,7 +1,7 @@
 ﻿// ReSharper disable InconsistentNaming
 
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
@@ -20,19 +20,19 @@ namespace EasyNetQ.Management.Client.Tests.Model
             permissionInfo = new PermissionInfo(user, vhost);
         }
 
-        [Test]
+        [Fact]
         public void Should_return_the_correct_user_name()
         {
             permissionInfo.GetUserName().ShouldEqual(user.Name);
         }
 
-        [Test]
+        [Fact]
         public void Should_return_the_correct_vhost_name()
         {
             permissionInfo.GetVirtualHostName().ShouldEqual(vhost.Name);
         }
 
-        [Test]
+        [Fact]
         public void Should_set_default_permissions_to_allow_all()
         {
             permissionInfo.Configure.ShouldEqual(".*");
@@ -40,7 +40,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             permissionInfo.Read.ShouldEqual(".*");
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_set_deny_permissions()
         {
             var permissions = permissionInfo.DenyAllConfigure().DenyAllRead().DenyAllWrite();
@@ -50,7 +50,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             permissions.Read.ShouldEqual("^$");
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_set_arbitrary_permissions()
         {
             var permissions = permissionInfo.SetConfigure("abc").SetRead("def").SetWrite("xyz");

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
@@ -21,28 +21,28 @@
         public void Should_read_apply_to_properly()
         {
             var exactlyPolicies = _policy.Where(p => p.Name == "ha-duplicate").ToList();
-            Assert.AreEqual(1, exactlyPolicies.Count);
+            Assert.Equal(1, exactlyPolicies.Count);
             var policy = exactlyPolicies.First();
-            Assert.AreEqual(ApplyMode.Queues, policy.ApplyTo);
+            Assert.Equal(ApplyMode.Queues, policy.ApplyTo);
 
             exactlyPolicies = _policy.Where(p => p.Name == "mirror_test").ToList();
-            Assert.AreEqual(1, exactlyPolicies.Count);
+            Assert.Equal(1, exactlyPolicies.Count);
             policy = exactlyPolicies.First();
-            Assert.AreEqual(ApplyMode.Exchanges, policy.ApplyTo);
+            Assert.Equal(ApplyMode.Exchanges, policy.ApplyTo);
 
             exactlyPolicies = _policy.Where(p => p.Name == "default apply to").ToList();
-            Assert.AreEqual(1, exactlyPolicies.Count);
+            Assert.Equal(1, exactlyPolicies.Count);
             policy = exactlyPolicies.First();
-            Assert.AreEqual(ApplyMode.All, policy.ApplyTo);   
+            Assert.Equal(ApplyMode.All, policy.ApplyTo);   
         }
 
            [Fact]
         public void Should_read_federation_upstream_properly()
         {
             var exactlyPolicies = _policy.Where(p => p.Name == "mirror_test").ToList();
-            Assert.AreEqual(1, exactlyPolicies.Count);
+            Assert.Equal(1, exactlyPolicies.Count);
             var policy = exactlyPolicies.First();
-            Assert.AreEqual("test", policy.Definition.FederationUpstream);
+            Assert.Equal("test", policy.Definition.FederationUpstream);
         }
 
         [Fact]
@@ -50,14 +50,14 @@
         {
             _policy.Count().ShouldEqual(3);
             var exactlyPolicies = _policy.Where(p => p.Name == "ha-duplicate");
-            Assert.AreEqual(1, exactlyPolicies.Count());
+            Assert.Equal(1, exactlyPolicies.Count());
             var policy = exactlyPolicies.First();
-            Assert.AreEqual(HaMode.Exactly, policy.Definition.HaMode);
-            Assert.AreEqual(HaMode.Exactly, policy.Definition.HaParams.AssociatedHaMode);
-            Assert.AreEqual(2, policy.Definition.HaParams.ExactlyCount);
-            Assert.AreEqual("^dup.*", policy.Pattern);
-            Assert.AreEqual(HaSyncMode.Manual, policy.Definition.HaSyncMode);
-            Assert.AreEqual(1, policy.Priority);
+            Assert.Equal(HaMode.Exactly, policy.Definition.HaMode);
+            Assert.Equal(HaMode.Exactly, policy.Definition.HaParams.AssociatedHaMode);
+            Assert.Equal(2, policy.Definition.HaParams.ExactlyCount);
+            Assert.Equal("^dup.*", policy.Pattern);
+            Assert.Equal(HaSyncMode.Manual, policy.Definition.HaSyncMode);
+            Assert.Equal(1, policy.Priority);
         }
 
         [Fact]
@@ -65,14 +65,14 @@
         {
             _policy.Count().ShouldEqual(3);
             var mirrorTestPolicies = _policy.Where(p => p.Name == "mirror_test");
-            Assert.AreEqual(1, mirrorTestPolicies.Count());
+            Assert.Equal(1, mirrorTestPolicies.Count());
             var policy = mirrorTestPolicies.First();
-            Assert.AreEqual(HaMode.Nodes, policy.Definition.HaMode);
-            Assert.AreEqual(HaMode.Nodes, policy.Definition.HaParams.AssociatedHaMode);
-            Assert.AreEqual(new[] { "rabbit@rab5", "rabbit@rab6" }, policy.Definition.HaParams.Nodes);
-            Assert.AreEqual("mirror", policy.Pattern);
-            Assert.AreEqual(HaSyncMode.Automatic, policy.Definition.HaSyncMode);
-            Assert.AreEqual(0, policy.Priority);
+            Assert.Equal(HaMode.Nodes, policy.Definition.HaMode);
+            Assert.Equal(HaMode.Nodes, policy.Definition.HaParams.AssociatedHaMode);
+            Assert.Equal(new[] { "rabbit@rab5", "rabbit@rab6" }, policy.Definition.HaParams.Nodes);
+            Assert.Equal("mirror", policy.Pattern);
+            Assert.Equal(HaSyncMode.Automatic, policy.Definition.HaSyncMode);
+            Assert.Equal(0, policy.Priority);
         }
 
         [Fact]
@@ -84,7 +84,7 @@
                 Pattern = "foo"
             }, ManagementClient.Settings);
             
-            Assert.IsTrue(serializedMessage.Contains("\"apply-to\":\"all\""));
+            Assert.True(serializedMessage.Contains("\"apply-to\":\"all\""));
 
             serializedMessage = JsonConvert.SerializeObject(new Policy
             {
@@ -93,7 +93,7 @@
                 ApplyTo = ApplyMode.Exchanges
             }, ManagementClient.Settings);
 
-            Assert.IsTrue(serializedMessage.Contains("\"apply-to\":\"exchanges\""));
+            Assert.True(serializedMessage.Contains("\"apply-to\":\"exchanges\""));
 
             serializedMessage = JsonConvert.SerializeObject(new Policy
             {
@@ -101,7 +101,7 @@
                 Pattern = "foo",
                 ApplyTo = ApplyMode.Queues
             }, ManagementClient.Settings);
-            Assert.IsTrue(serializedMessage.Contains("\"apply-to\":\"queues\""));
+            Assert.True(serializedMessage.Contains("\"apply-to\":\"queues\""));
         }
 
         [Fact]
@@ -114,7 +114,7 @@
                 Definition = new PolicyDefinition { FederationUpstream = "my-upstream"}
             }, ManagementClient.Settings);
 
-            Assert.IsTrue(serializedMessage.Contains("\"federation-upstream\":\"my-upstream\""));
+            Assert.True(serializedMessage.Contains("\"federation-upstream\":\"my-upstream\""));
         }
 
         [Fact]
@@ -127,8 +127,8 @@
                 Definition = new PolicyDefinition {HaMode = HaMode.All}
             }, ManagementClient.Settings);
             Console.WriteLine(serializedMessage);
-            Assert.IsFalse(serializedMessage.Contains("ha-params"));
-            Assert.IsFalse(serializedMessage.Contains("federation_upstream_set"));
+            Assert.False(serializedMessage.Contains("ha-params"));
+            Assert.False(serializedMessage.Contains("federation_upstream_set"));
         }
 
     }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
@@ -4,7 +4,7 @@
     using System.Linq;
     using Client.Model;
     using Newtonsoft.Json;
-    using NUnit.Framework;
+    using Xunit;
 
     [TestFixture(Category = "Unit")]
     public class PolicySerializationTests
@@ -17,7 +17,7 @@
             _policy = ResourceLoader.LoadObjectFromJson<Policy[]>("Policies_ha.json", ManagementClient.Settings);
         }
 
-        [Test]
+        [Fact]
         public void Should_read_apply_to_properly()
         {
             var exactlyPolicies = _policy.Where(p => p.Name == "ha-duplicate").ToList();
@@ -36,7 +36,7 @@
             Assert.AreEqual(ApplyMode.All, policy.ApplyTo);   
         }
 
-           [Test]
+           [Fact]
         public void Should_read_federation_upstream_properly()
         {
             var exactlyPolicies = _policy.Where(p => p.Name == "mirror_test").ToList();
@@ -45,7 +45,7 @@
             Assert.AreEqual("test", policy.Definition.FederationUpstream);
         }
 
-        [Test]
+        [Fact]
         public void Should_read_exactly_ha_properly()
         {
             _policy.Count().ShouldEqual(3);
@@ -60,7 +60,7 @@
             Assert.AreEqual(1, policy.Priority);
         }
 
-        [Test]
+        [Fact]
         public void Should_read_nodes_ha_properly()
         {
             _policy.Count().ShouldEqual(3);
@@ -75,7 +75,7 @@
             Assert.AreEqual(0, policy.Priority);
         }
 
-        [Test]
+        [Fact]
         public void Should_write_apply_to_properly()
         {
             var serializedMessage = JsonConvert.SerializeObject(new Policy
@@ -104,7 +104,7 @@
             Assert.IsTrue(serializedMessage.Contains("\"apply-to\":\"queues\""));
         }
 
-        [Test]
+        [Fact]
         public void Should_write_federation_upstream_properly()
         {
             var serializedMessage = JsonConvert.SerializeObject(new Policy
@@ -117,7 +117,7 @@
             Assert.IsTrue(serializedMessage.Contains("\"federation-upstream\":\"my-upstream\""));
         }
 
-        [Test]
+        [Fact]
         public void Should_write_all_ha_policy_without_param()
         {
             var serializedMessage = JsonConvert.SerializeObject(new Policy

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PolicySerializationTests.cs
@@ -6,13 +6,11 @@
     using Newtonsoft.Json;
     using Xunit;
 
-    [TestFixture(Category = "Unit")]
     public class PolicySerializationTests
     {
-        private Policy[] _policy;
+        private readonly Policy[] _policy;
 
-        [SetUp]
-        public void SetUp()
+        public PolicySerializationTests()
         {
             _policy = ResourceLoader.LoadObjectFromJson<Policy[]>("Policies_ha.json", ManagementClient.Settings);
         }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
@@ -3,23 +3,17 @@
 using System;
 using System.Collections.Generic;
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class PublishInfoTests
     {
-        [SetUp]
-        public void SetUp()
-        {
-        }
-
         [Fact]
-        [ExpectedException(typeof(ArgumentException), ExpectedMessage = "payloadEncoding must be one of: 'string, base64'")]
         public void Should_throw_when_payload_encoding_is_incorrect()
         {
-            new PublishInfo(new Dictionary<string, string>(), "routing_key", "payload", "unknown_payload_encoding");
+            //payloadEncoding must be one of: 'string, base64'
+            Assert.Throws<ArgumentException>(() => new PublishInfo(new Dictionary<string, string>(), "routing_key", "payload", "unknown_payload_encoding"));
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
@@ -15,7 +15,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
         {
         }
 
-        [Test]
+        [Fact]
         [ExpectedException(typeof(ArgumentException), ExpectedMessage = "payloadEncoding must be one of: 'string, base64'")]
         public void Should_throw_when_payload_encoding_is_incorrect()
         {

--- a/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
@@ -2,16 +2,15 @@
 
 using System.Collections.Generic;
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class QueueSerializationTests
     {
         private List<Queue> queues;
 
-        [Test]
+        [Fact]
         public void BackingQueueStatus_With_NextSeqId_Exceeding_IntMaxLength_Can_Be_Deserialized()
         {
             queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");
@@ -21,7 +20,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             queue.BackingQueueStatus.NextSeqId.ShouldEqual(((long)int.MaxValue) + 1);
         }
 
-        [Test]
+        [Fact]
         public void NonInt_Consumer_Details_Channel_Details_Peer_Port_Can_Be_Deserialize()
         {
             queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");
@@ -31,7 +30,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             queue.ConsumerDetails[0].ChannelDetails.PeerPort.ShouldEqual(0);
         }
 
-        [Test]
+        [Fact]
         public void Int_Consumer_Details_Channel_Details_Peer_Port_Can_Be_Deserialize()
         {
             queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");

--- a/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
@@ -19,14 +19,14 @@ namespace EasyNetQ.Management.Client.Tests.Model
             userInfo = new UserInfo(userName, password);
         }
 
-        [Test]
+        [Fact]
         public void Should_have_correct_name_and_password()
         {
             userInfo.GetName().ShouldEqual(userName);
             userInfo.Password.ShouldEqual(password);
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_add_tags()
         {
             userInfo.AddTag("administrator").AddTag("management");
@@ -45,7 +45,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
             userInfo.AddTag("blah");
         }
 
-        [Test]
+        [Fact]
         public void Should_have_a_default_tag_of_empty_string()
         {
             userInfo.Tags.ShouldEqual("");

--- a/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/UserInfoTests.cs
@@ -2,19 +2,17 @@
 
 using System;
 using EasyNetQ.Management.Client.Model;
-using NUnit.Framework;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests.Model
 {
-    [TestFixture(Category = "Unit")]
     public class UserInfoTests
     {
-        private UserInfo userInfo;
+        private readonly UserInfo userInfo;
         private const string userName = "mike";
         private const string password = "topSecret";
 
-        [SetUp]
-        public void SetUp()
+        public UserInfoTests()
         {
             userInfo = new UserInfo(userName, password);
         }
@@ -33,16 +31,16 @@ namespace EasyNetQ.Management.Client.Tests.Model
             userInfo.Tags.ShouldEqual("administrator,management");
         }
 
-        [Test, ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void Should_not_be_able_to_add_the_same_tag_twice()
         {
-            userInfo.AddTag("management").AddTag("management");
+            Assert.Throws<ArgumentException>(() => userInfo.AddTag("management").AddTag("management"));
         }
 
-        [Test, ExpectedException(typeof(ArgumentException))]
+        [Fact]
         public void Should_not_be_able_to_add_incorrect_tags()
         {
-            userInfo.AddTag("blah");
+            Assert.Throws<ArgumentException>(() => userInfo.AddTag("blah"));
         }
 
         [Fact]

--- a/Source/EasyNetQ.Management.Client.Tests/ResourceLoader.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ResourceLoader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Reflection;
 using EasyNetQ.Management.Client.Serialization;
 using Newtonsoft.Json;
@@ -23,11 +22,12 @@ namespace EasyNetQ.Management.Client.Tests
             settings.Converters.Add(new PropertyConverter());
             return LoadObjectFromJson<T>(fileToLoad, settings);
         }
+
         public static T LoadObjectFromJson<T>(string fileToLoad, JsonSerializerSettings settings)
         {
             const string namespaceFormat = "EasyNetQ.Management.Client.Tests.Json.{0}";
             var resourceName = string.Format(namespaceFormat, fileToLoad);
-            var assembly = Assembly.GetExecutingAssembly();
+            var assembly = typeof(ResourceLoader).GetTypeInfo().Assembly;
             string contents;
             using(var resourceStream = assembly.GetManifestResourceStream(resourceName))
             {

--- a/Source/EasyNetQ.Management.Client.Tests/ResourceLoader.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ResourceLoader.cs
@@ -33,7 +33,7 @@ namespace EasyNetQ.Management.Client.Tests
             {
                 if (resourceStream == null)
                 {
-                    throw new ApplicationException("Couldn't load resource stream: " + resourceName);
+                    throw new EasyNetQTestException("Couldn't load resource stream: " + resourceName);
                 }
                 using (var reader = new StreamReader(resourceStream))
                 {

--- a/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
@@ -11,8 +11,8 @@
         [Fact]
         public void Should_only_handle_HaParams()
         {
-            Assert.IsTrue(new HaParamsConverter().CanConvert(typeof(HaParams)));
-            Assert.IsFalse(new HaParamsConverter().CanConvert(typeof(HaMode)));
+            Assert.True(new HaParamsConverter().CanConvert(typeof(HaParams)));
+            Assert.False(new HaParamsConverter().CanConvert(typeof(HaMode)));
         }
 
         [Fact]
@@ -20,8 +20,8 @@
         {
             var deserializedObject = JsonConvert.DeserializeObject<HaParams>("5", new HaParamsConverter());
             Assert.NotNull(deserializedObject);
-            Assert.AreEqual(HaMode.Exactly, deserializedObject.AssociatedHaMode);
-            Assert.AreEqual(5L, deserializedObject.ExactlyCount);
+            Assert.Equal(HaMode.Exactly, deserializedObject.AssociatedHaMode);
+            Assert.Equal(5L, deserializedObject.ExactlyCount);
         }
 
         [Fact]
@@ -29,9 +29,9 @@
         {
             var deserializedObject = JsonConvert.DeserializeObject<HaParams>("[\"a\", \"b\"]", new HaParamsConverter());
             Assert.NotNull(deserializedObject);
-            Assert.AreEqual(HaMode.Nodes, deserializedObject.AssociatedHaMode);
+            Assert.Equal(HaMode.Nodes, deserializedObject.AssociatedHaMode);
             Assert.NotNull(deserializedObject.Nodes);
-            Assert.AreEqual(2, deserializedObject.Nodes.Length);
+            Assert.Equal(2, deserializedObject.Nodes.Length);
             Assert.Contains("a", deserializedObject.Nodes);
             Assert.Contains("b", deserializedObject.Nodes);
         }
@@ -46,13 +46,13 @@
         [Fact]
         public void Should_be_able_to_serialize_count()
         {
-            Assert.AreEqual("2", JsonConvert.SerializeObject(new HaParams{AssociatedHaMode = HaMode.Exactly, ExactlyCount = 2}, new HaParamsConverter()));
+            Assert.Equal("2", JsonConvert.SerializeObject(new HaParams{AssociatedHaMode = HaMode.Exactly, ExactlyCount = 2}, new HaParamsConverter()));
         }
 
         [Fact]
         public void Should_be_able_to_serialize_list()
         {
-            Assert.AreEqual(JsonConvert.SerializeObject(new[] { "a", "b" }), JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes, Nodes = new[] { "a", "b" } }, new HaParamsConverter()));
+            Assert.Equal(JsonConvert.SerializeObject(new[] { "a", "b" }), JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes, Nodes = new[] { "a", "b" } }, new HaParamsConverter()));
         }
 
         [Fact]

--- a/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
@@ -8,14 +8,14 @@
     [TestFixture(Category = "Unit")]
     class HaParamsConverterTests
     {
-        [Test]
+        [Fact]
         public void Should_only_handle_HaParams()
         {
             Assert.IsTrue(new HaParamsConverter().CanConvert(typeof(HaParams)));
             Assert.IsFalse(new HaParamsConverter().CanConvert(typeof(HaMode)));
         }
 
-        [Test]
+        [Fact]
         public void Should_deserialize_exactly_count()
         {
             var deserializedObject = JsonConvert.DeserializeObject<HaParams>("5", new HaParamsConverter());
@@ -24,7 +24,7 @@
             Assert.AreEqual(5L, deserializedObject.ExactlyCount);
         }
 
-        [Test]
+        [Fact]
         public void Should_deserialize_nodes_list()
         {
             var deserializedObject = JsonConvert.DeserializeObject<HaParams>("[\"a\", \"b\"]", new HaParamsConverter());
@@ -36,33 +36,33 @@
             Assert.Contains("b", deserializedObject.Nodes);
         }
 
-        [Test]
+        [Fact]
         [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_deserialize_non_string_list()
         {
             JsonConvert.DeserializeObject<HaParams>("[1,2]", new HaParamsConverter());
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_serialize_count()
         {
             Assert.AreEqual("2", JsonConvert.SerializeObject(new HaParams{AssociatedHaMode = HaMode.Exactly, ExactlyCount = 2}, new HaParamsConverter()));
         }
 
-        [Test]
+        [Fact]
         public void Should_be_able_to_serialize_list()
         {
             Assert.AreEqual(JsonConvert.SerializeObject(new[] { "a", "b" }), JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes, Nodes = new[] { "a", "b" } }, new HaParamsConverter()));
         }
 
-        [Test]
+        [Fact]
         [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_serialize_null_nodes_list()
         {
             JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes }, new HaParamsConverter());
         }
 
-        [Test]
+        [Fact]
         [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_serialize_all_type()
         {

--- a/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Serialization/HaParamsConverterTests.cs
@@ -3,10 +3,9 @@
     using Client.Model;
     using Client.Serialization;
     using Newtonsoft.Json;
-    using NUnit.Framework;
+    using Xunit;
 
-    [TestFixture(Category = "Unit")]
-    class HaParamsConverterTests
+    public class HaParamsConverterTests
     {
         [Fact]
         public void Should_only_handle_HaParams()
@@ -37,10 +36,9 @@
         }
 
         [Fact]
-        [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_deserialize_non_string_list()
         {
-            JsonConvert.DeserializeObject<HaParams>("[1,2]", new HaParamsConverter());
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<HaParams>("[1,2]", new HaParamsConverter()));
         }
 
         [Fact]
@@ -56,17 +54,15 @@
         }
 
         [Fact]
-        [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_serialize_null_nodes_list()
         {
-            JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes }, new HaParamsConverter());
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.Nodes }, new HaParamsConverter()));
         }
 
         [Fact]
-        [ExpectedException(typeof(JsonSerializationException))]
         public void Should_not_be_able_to_serialize_all_type()
         {
-            JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.All, Nodes = new[] { "a", "b" } }, new HaParamsConverter());
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.SerializeObject(new HaParams { AssociatedHaMode = HaMode.All, Nodes = new[] { "a", "b" } }, new HaParamsConverter()));
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
@@ -12,12 +12,6 @@ namespace EasyNetQ.Management.Client.Tests
             return obj;
         }
 
-        public static T ShouldNotBeNull<T>(this T obj, string message)
-        {
-            Assert.NotNull(obj, message);
-            return obj;
-        }
-
         public static T ShouldEqual<T>(this T actual, object expected)
         {
             Assert.Equal(expected, actual);
@@ -27,13 +21,6 @@ namespace EasyNetQ.Management.Client.Tests
         public static T ShouldNotEqual<T>(this T actual, object expected)
         {
             Assert.NotEqual(expected, actual);
-            return actual;
-        }
-
-
-        public static T ShouldEqual<T>(this T actual, object expected, string message)
-        {
-            Assert.Equal(expected, actual, message);
             return actual;
         }
 

--- a/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/TestExtensions.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Linq;
-using NUnit.Framework;
 using System.Collections.Generic;
+using Xunit;
 
 namespace EasyNetQ.Management.Client.Tests
 {
@@ -9,53 +8,53 @@ namespace EasyNetQ.Management.Client.Tests
     {
         public static T ShouldNotBeNull<T>(this T obj)
         {
-            Assert.IsNotNull(obj);
+            Assert.NotNull(obj);
             return obj;
         }
 
         public static T ShouldNotBeNull<T>(this T obj, string message)
         {
-            Assert.IsNotNull(obj, message);
+            Assert.NotNull(obj, message);
             return obj;
         }
 
         public static T ShouldEqual<T>(this T actual, object expected)
         {
-            Assert.AreEqual(expected, actual);
+            Assert.Equal(expected, actual);
             return actual;
         }
 
         public static T ShouldNotEqual<T>(this T actual, object expected)
         {
-            Assert.AreNotEqual(expected, actual);
+            Assert.NotEqual(expected, actual);
             return actual;
         }
 
 
         public static T ShouldEqual<T>(this T actual, object expected, string message)
         {
-            Assert.AreEqual(expected, actual, message);
+            Assert.Equal(expected, actual, message);
             return actual;
         }
 
-        public static Exception ShouldBeThrownBy(this Type exceptionType, TestDelegate testDelegate)
+        public static Exception ShouldBeThrownBy(this Type exceptionType, Action testDelegate)
         {
             return Assert.Throws(exceptionType, testDelegate);
         }
 
         public static void ShouldBe<T>(this object actual)
         {
-            Assert.IsInstanceOf<T>(actual);
+            Assert.IsType<T>(actual);
         }
 
         public static void ShouldBeNull(this object actual)
         {
-            Assert.IsNull(actual);
+            Assert.Null(actual);
         }
 
         public static void ShouldBeTheSameAs(this object actual, object expected)
         {
-            Assert.AreSame(expected, actual);
+            Assert.Same(expected, actual);
         }
 
         public static T CastTo<T>(this object source)
@@ -65,28 +64,27 @@ namespace EasyNetQ.Management.Client.Tests
 
         public static void ShouldBeTrue(this bool source)
         {
-            Assert.IsTrue(source);
+            Assert.True(source);
         }
 
         public static void ShouldBeTrue(this bool source, string message)
         {
-            Assert.IsTrue(source, message);
+            Assert.True(source, message);
         }
 
         public static void ShouldBeFalse(this bool source)
         {
-            Assert.IsFalse(source);
+            Assert.False(source);
         }
 
         public static void ShouldBeFalse(this bool source, string message)
         {
-            Assert.IsFalse(source, message);
+            Assert.False(source, message);
         }
 
         public static void ShouldBeEmpty<T>(this IEnumerable<T> collection)
         {
-            Assert.AreEqual(collection.Count(), 0,
-            string.Format("Expected collection to be empty, but had {0} items", collection.Count()));
+            Assert.Empty(collection);
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/project.json
+++ b/Source/EasyNetQ.Management.Client.Tests/project.json
@@ -3,7 +3,8 @@
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "xunit": "2.2.0-beta2-build3300"
+    "xunit": "2.2.0-beta2-build3300",
+    "xunit.runner.visualstudio": "2.2.0-beta2-build1149"
   },
   "testRunner": "xunit",
   "buildOptions": {
@@ -13,12 +14,6 @@
     }
   },
   "frameworks": {
-    "net451": {
-      "frameworkAssemblies": {
-        "Microsoft.CSharp": "4.0.0.0",
-        "System.Net.Http": "4.0.0.0"
-      }
-    },
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {
@@ -29,6 +24,7 @@
     }
   },
   "runtimes": {
-    "win": {}
+    "win7-x86": {},
+    "win7-x64": {}
   }
 }

--- a/Source/EasyNetQ.Management.Client.Tests/project.json
+++ b/Source/EasyNetQ.Management.Client.Tests/project.json
@@ -1,10 +1,11 @@
 ﻿{
   "dependencies": {
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "xunit": "2.2.0-beta2-build3300"
   },
+  "testRunner": "xunit",
   "buildOptions": {
     "embed": [ "Json/*" ],
     "compile": {
@@ -16,6 +17,14 @@
       "frameworkAssemblies": {
         "Microsoft.CSharp": "4.0.0.0",
         "System.Net.Http": "4.0.0.0"
+      }
+    },
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.1"
+        }
       }
     }
   },

--- a/Source/EasyNetQ.Management.Client.Tests/project.json
+++ b/Source/EasyNetQ.Management.Client.Tests/project.json
@@ -2,7 +2,8 @@
   "dependencies": {
     "EasyNetQ.Management.Client": "2.0.0-netcore0001",
     "Newtonsoft.Json": "9.0.1",
-    "NUnit": "2.6.4"
+    "xunit": "2.2.0-beta2-build3300",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "buildOptions": {
     "embed": [ "Json/*" ],


### PR DESCRIPTION
- Moves tests from NUnit to xUnit
  - xUnit does not have a "[Category]", so I added a [CategoryDiscoverer](https://github.com/conniey/EasyNetQ.Management.Client/blob/3f049e35586da4981be61552e12f868ee04ebe7b/Source/EasyNetQ.Management.Client.IntegrationTests/Traits/CategoryAttribute.cs) that simulates categories and a usage of it in [Build\EasyNetQ.proj](https://github.com/conniey/EasyNetQ.Management.Client/blob/3f049e35586da4981be61552e12f868ee04ebe7b/Build/EasyNetQ.proj#L55)
- Adds xUnit AppVeyor integration (ie. [Sample results](https://ci.appveyor.com/project/conniey/easynetq-management-client/build/tests))
