### PR TITLE
Fixing branch names in GitVersion

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,12 +3,7 @@ mode: ContinuousDelivery
 branches:
   master:
     mode: ContinuousDelivery
-    tag: ''
-    prevent-increment-of-merged-branch-version: true
-  feature:
-    mode: ContinuousDelivery
-    tag: useBranchName
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: false
+  features?[/-]:
+    mode: ContinuousDeployment
 ignore:
   sha: []


### PR DESCRIPTION
I was looking at the [CI builds](https://ci.appveyor.com/project/EasyNetQ/easynetq-management-client/build/1.0.113#L104) and noticed that the build was failing due to this error:

```
System.Exception: Multiple branch configurations match the current branch branchName of 'feature/netcore'. Matching configurations: 'feature, features?[/-]'
```

It looks like it may be due to: [GitVersion #715](https://github.com/GitTools/GitVersion/issues/715).  So, I fixed the branch name in the GitVersion.yml file.