### PR TITLE
Extended DeleteBinding method (delete binding between exchanges)

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1080,8 +1080,6 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             Assert.NotNull(parameters);
         }
 
-
-
         [Test]
         [Ignore("Requires the federation plugin to work")]
         public void Should_be_able_to_create_parameter()

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1032,11 +1032,55 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         }
 
         [Test]
+        public void Should_be_able_to_delete_binding_between_exchange_and_queue()
+        {
+            var exchangeSourceName = "management_api_test_exchange_source";
+            var queueName = "management_api_test_queue_destination";
+            var vhost = new Vhost { Name = vhostName };
+            var exchangeSource = CreateExchange(exchangeSourceName);
+            var queue = CreateTestQueue(queueName);
+            managementClient.CreateBinding(exchangeSource, queue, new BindingInfo(null));
+            var binding = managementClient.GetBindings(exchangeSource, queue).First();
+
+            try
+            {
+                managementClient.DeleteBinding(binding);
+            }
+            finally
+            {
+                managementClient.DeleteExchange(exchangeSource);
+                managementClient.DeleteQueue(queue);
+            }
+        }
+
+        [Test]
+        public void Should_be_able_to_delete_binding_between_exchange_and_exchange()
+        {
+            var exchangeSourceName = "management_api_test_exchange_source";
+            var exchangeDestinationName = "management_api_test_exchange_destination";
+            var exchangeSource = CreateExchange(exchangeSourceName);
+            var exchangeDestination = CreateExchange(exchangeDestinationName);
+            managementClient.CreateBinding(exchangeSource, exchangeDestination, new BindingInfo("#"));
+            var binding = managementClient.GetBindings(exchangeSource, exchangeDestination).First();
+            try
+            {
+                managementClient.DeleteBinding(binding);
+            }
+            finally
+            {
+                managementClient.DeleteExchange(exchangeSource);
+                managementClient.DeleteExchange(exchangeDestination);
+            }
+        }
+
+        [Test]
         public void Should_be_able_to_list_parameters()
         {
             var parameters = managementClient.GetParameters();
             Assert.NotNull(parameters);
         }
+
+
 
         [Test]
         [Ignore("Requires the federation plugin to work")]

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -384,9 +384,25 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("binding");
             }
 
-            Delete(string.Format("bindings/{0}/e/{1}/q/{2}/{3}",
+            if (string.IsNullOrEmpty(binding.Source))
+            {
+                throw new ArgumentException("Empty binding source isn't supported.");
+            }
+
+            if (string.IsNullOrEmpty(binding.Destination))
+            {
+                throw new ArgumentException("Empty binding destination isn't supported.");
+            }
+
+            if (string.IsNullOrEmpty(binding.DestinationType))
+            {
+                throw new ArgumentException("Empty binding destination type isn't supported.");
+            }
+
+            Delete(string.Format("bindings/{0}/e/{1}/{2}/{3}/{4}",
                 SanitiseVhostName(binding.Vhost),
                 binding.Source,
+                binding.DestinationType[0], // e for exchange or q for queue
                 binding.Destination,
                 RecodeBindingPropertiesKey(binding.PropertiesKey)));
         }


### PR DESCRIPTION
DeleteBinding method failed with bindings between exchanges.

Reason for this is that there are two different api paths to work with bindings:
/api/bindings/vhost/e/exchange/q/queue/props - api for actions with binding between exchange and queue
/api/bindings/vhost/e/source/e/destination/props - api path for actions with binding between exchanges.

Added posibility to delete bindings between exchanges.
Added two integration tests to illustrate the change.

closes #43 