### PR TITLE
Support deleting exchange to exchange bindings

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1061,6 +1061,48 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             });
             Assert.True(managementClient.GetParameters().Where(p=>p.Name == "myfakefederationupstream").Any());
         }
+
+        [Fact]
+        public void Should_be_able_to_delete_binding_between_exchange_and_queue()
+        {
+            var exchangeSourceName = "management_api_test_exchange_source";
+            var queueName = "management_api_test_queue_destination";
+            var vhost = new Vhost { Name = vhostName };
+            var exchangeSource = CreateExchange(exchangeSourceName);
+            var queue = CreateTestQueue(queueName);
+            managementClient.CreateBinding(exchangeSource, queue, new BindingInfo(null));
+            var binding = managementClient.GetBindings(exchangeSource, queue).First();
+
+            try
+            {
+                managementClient.DeleteBinding(binding);
+            }
+            finally
+            {
+                managementClient.DeleteExchange(exchangeSource);
+                managementClient.DeleteQueue(queue);
+            }
+        }
+
+        [Fact]
+        public void Should_be_able_to_delete_binding_between_exchange_and_exchange()
+        {
+            var exchangeSourceName = "management_api_test_exchange_source";
+            var exchangeDestinationName = "management_api_test_exchange_destination";
+            var exchangeSource = CreateExchange(exchangeSourceName);
+            var exchangeDestination = CreateExchange(exchangeDestinationName);
+            managementClient.CreateBinding(exchangeSource, exchangeDestination, new BindingInfo("#"));
+            var binding = managementClient.GetBindings(exchangeSource, exchangeDestination).First();
+            try
+            {
+                managementClient.DeleteBinding(binding);
+            }
+            finally
+            {
+                managementClient.DeleteExchange(exchangeSource);
+                managementClient.DeleteExchange(exchangeDestination);
+            }
+        }
     }
 }
 

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -393,9 +393,25 @@ namespace EasyNetQ.Management.Client
                 throw new ArgumentNullException("binding");
             }
 
-            Delete(string.Format("bindings/{0}/e/{1}/q/{2}/{3}",
+            if (string.IsNullOrEmpty(binding.Source))
+            {
+                throw new ArgumentException("Empty binding source isn't supported.");
+            }
+
+            if (string.IsNullOrEmpty(binding.Destination))
+            {
+                throw new ArgumentException("Empty binding destination isn't supported.");
+            }
+
+            if (string.IsNullOrEmpty(binding.DestinationType))
+            {
+                throw new ArgumentException("Empty binding destination type isn't supported.");
+            }
+
+            Delete(string.Format("bindings/{0}/e/{1}/{2}/{3}/{4}",
                 SanitiseVhostName(binding.Vhost),
                 binding.Source,
+                binding.DestinationType[0], // e for exchange or q for queue
                 binding.Destination,
                 RecodeBindingPropertiesKey(binding.PropertiesKey)));
         }


### PR DESCRIPTION
I updated DeleteBinding method on feature/netcore branch. Added Xunit tests instead of NUnit.
I am not sure if these actions are exactly what @micdenny asked for me.