### PR TITLE
Prevent ChannelDetail.Number serialization exception

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
@@ -204,7 +204,7 @@
       {
         "channel_details": {
           "name": "channel_details_name",
-          "number": 1,
+          "number": "unknown",
           "user": "none",
           "connection_name": "channel_details_connection_name",
           "peer_port": "unknown",

--- a/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/QueueSerializationTests.cs
@@ -39,6 +39,26 @@ namespace EasyNetQ.Management.Client.Tests.Model
 
             queue.ConsumerDetails[0].ChannelDetails.PeerPort.ShouldEqual(9861);
         }
+
+        [Fact]
+        public void NonInt_Consumer_Details_Channel_Details_Number_Can_Be_Deserialized()
+        {
+            queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");
+
+            var queue = queues[2];
+
+            queue.ConsumerDetails[0].ChannelDetails.Number.ShouldEqual(0);
+        }
+
+        [Fact]
+        public void Int_Consumer_Details_Channel_Details_Number_Can_Be_Deserialized()
+        {
+            queues = ResourceLoader.LoadObjectFromJson<List<Queue>>("Queues.json");
+
+            var queue = queues[3];
+
+            queue.ConsumerDetails[0].ChannelDetails.Number.ShouldEqual(1);
+        }
     }
 }
 

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -39,7 +39,8 @@ namespace EasyNetQ.Management.Client.Model
     public class ChannelDetail
     {
         public string Name { get; set; }
-        public int Number { get; set; }
+	[JsonConverter(typeof(TolerantInt32Converter))]
+        public int Number { get; set; }	    
         public string User { get; set; }
         public string ConnectionName { get; set; }
         [JsonConverter(typeof(TolerantInt32Converter))]

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -39,7 +39,7 @@ namespace EasyNetQ.Management.Client.Model
     public class ChannelDetail
     {
         public string Name { get; set; }
-	[JsonConverter(typeof(TolerantInt32Converter))]
+        [JsonConverter(typeof(TolerantInt32Converter))]
         public int Number { get; set; }	    
         public string User { get; set; }
         public string ConnectionName { get; set; }


### PR DESCRIPTION
Fixed serialization exception for cases when queue.consumer_details[0].channel_details.Number="unknown"