### PR TITLE
Create user using password_hash.

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -621,6 +621,28 @@ namespace EasyNetQ.Management.Client.IntegrationTests
         }
 
         [Test]
+        public void Should_be_able_to_create_a_user_with_password_hash()
+        {
+            var testUser = "hash_user";
+            //Hash calculated using RabbitMq hash computing algorithm using Sha256. See https://www.rabbitmq.com/passwords.html.
+            var passwordHash = "Qlp9Dgrqvx1S1VkuYsoWwgUD2XW2gZLuqQwreE+PAsPZETgo"; //"topSecret"
+            var userInfo = new UserInfo(testUser, passwordHash, isHashed:true).AddTag("administrator");
+
+            var user = managementClient.CreateUser(userInfo);
+            user.Name.ShouldEqual(testUser);
+        }
+        
+        [Test]
+        public void Should_be_able_to_create_a_user_without_password()
+        {
+            var testUser = "empty";
+            var userInfo = new UserInfo(testUser, "", isHashed:true).AddTag("administrator");
+
+            var user = managementClient.CreateUser(userInfo);
+            user.Name.ShouldEqual(testUser);
+        }
+        
+        [Test]
         public void Should_be_able_to_create_a_user_with_the_policymaker_tag()
         {
             var userInfo = new UserInfo(testUser, "topSecret").AddTag("policymaker");

--- a/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/UserInfo.cs
@@ -8,6 +8,7 @@ namespace EasyNetQ.Management.Client.Model
     {
         private readonly string name;
         public string Password { get; private set; }
+        public string PasswordHash { get; private set; }
         public string Tags
         {
             get
@@ -25,19 +26,36 @@ namespace EasyNetQ.Management.Client.Model
 
         private readonly ISet<string> tagList = new HashSet<string>();
 
-        public UserInfo(string name, string password)
+        /// <summary>
+        /// Creates <see cref="UserInfo"/> instance.
+        /// </summary>
+        /// <param name="name">User name</param>
+        /// <param name="password">Password or password hash value.</param>
+        /// <param name="isHashed">Flag shows if <param name="password">password</param> value is raw password or password hash.</param>
+        /// <remarks>Hash should be calculated using RabbitMq hash computing algorithm.
+        /// See https://www.rabbitmq.com/passwords.html.</remarks>
+        /// <exception cref="ArgumentException"></exception>
+        public UserInfo(string name, string password, bool isHashed = false)
         {
             if (string.IsNullOrEmpty(name))
             {
                 throw new ArgumentException("name is null or empty");
             }
-            if (string.IsNullOrEmpty(password))
+            //Setting password_hash to "" will ensure the user cannot use a password to log in. 
+            //(From HTTP API documentation: https://cdn.rawgit.com/rabbitmq/rabbitmq-management/rabbitmq_v3_6_12/priv/www/api/index.html)
+            if (string.IsNullOrEmpty(password) && !isHashed)
             {
-                throw new ArgumentException("password is null or empty");
+                throw new ArgumentException("password is null or empty.");
             }
-
             this.name = name;
-            this.Password = password;
+            if (isHashed)
+            {
+                this.PasswordHash = password;
+            }
+            else
+            {
+                this.Password = password;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Implementation of #51 [Create user using password hash](https://github.com/EasyNetQ/EasyNetQ.Management.Client/issues/51).
Extenden `UserInfo` class with `PasswordHash` property, updated constructor to handle `PasswordHash` property.
Added several unit tests to cover changes.

Change also adds possibility to create user without password. From [RabbitMQ Management HTTP API documentation](https://cdn.rawgit.com/rabbitmq/rabbitmq-management/rabbitmq_v3_6_12/priv/www/api/index.html):

> Setting password_hash to "" will ensure the user cannot use a password to log in.
