### PR TITLE
Allow publish properties to be objects. headers property must be an o…

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -413,7 +413,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
             var defaultExchange = new Exchange { Name = "amq.default", Vhost = vhostName };
 
-            var properties = new Dictionary<string, string>
+            var properties = new Dictionary<string, object>
             {
                 { "app_id", "management-test"}
             };

--- a/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/PublishInfoTests.cs
@@ -19,7 +19,7 @@ namespace EasyNetQ.Management.Client.Tests.Model
         [ExpectedException(typeof(ArgumentException), ExpectedMessage = "payloadEncoding must be one of: 'string, base64'")]
         public void Should_throw_when_payload_encoding_is_incorrect()
         {
-            new PublishInfo(new Dictionary<string, string>(), "routing_key", "payload", "unknown_payload_encoding");
+            new PublishInfo(new Dictionary<string, object>(), "routing_key", "payload", "unknown_payload_encoding");
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/PublishInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PublishInfo.cs
@@ -5,14 +5,14 @@ namespace EasyNetQ.Management.Client.Model
 {
     public class PublishInfo
     {
-        public IDictionary<string, string> Properties { get; private set; }
+        public IDictionary<string, object> Properties { get; private set; }
         public string RoutingKey { get; private set; }
         public string Payload { get; private set; }
         public string PayloadEncoding { get; private set; }
 
         private readonly ISet<string> payloadEncodings = new HashSet<string> { "string", "base64" };
 
-        public PublishInfo(IDictionary<string, string> properties, string routingKey, string payload, string payloadEncoding)
+        public PublishInfo(IDictionary<string, object> properties, string routingKey, string payload, string payloadEncoding)
         {
             if (properties == null)
             {
@@ -43,7 +43,7 @@ namespace EasyNetQ.Management.Client.Model
         }
 
         public PublishInfo(string routingKey, string payload) :
-            this(new Dictionary<string, string>(), routingKey, payload, "string")
+            this(new Dictionary<string, object>(), routingKey, payload, "string")
         {
         }
     }


### PR DESCRIPTION
…bject rather than a string or RabbitMQ returns a 500 error. #56