### PR TITLE
PolicyDefinition: removed unessesary JsonProperty attribute.

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/PolicyDefinition.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PolicyDefinition.cs
@@ -22,7 +22,6 @@
         public string DeadLetterRoutingKey { get; set; }
         [JsonProperty("message-ttl", NullValueHandling = NullValueHandling.Ignore)]
         public uint? MessageTtl { get; set; }
-        [JsonProperty("expires", NullValueHandling = NullValueHandling.Ignore)]
         public uint? Expires { get; set; }
         [JsonProperty("max-length", NullValueHandling = NullValueHandling.Ignore)]
         public uint? MaxLength { get; set; }


### PR DESCRIPTION
Removed unnecessary `[JSonProperty]` attribute from `PolicyDefinition.Expires` property.  This property is handled correctly applying default `JsonSerializerSettings` used by `ManagementClient`.