### PR TITLE
Enable/disable tracing on vhost.

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1085,6 +1085,25 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             });
             Assert.True(managementClient.GetParameters().Where(p=>p.Name == "myfakefederationupstream").Any());
         }
+
+        [Test]
+        public void Should_enable_tracing()
+        {
+            var vhost = managementClient.GetVhost(vhostName);
+            managementClient.EnableTracing(vhost);
+
+            var vhostAfterUpdate = managementClient.GetVhost(vhostName);
+            Assert.True(vhostAfterUpdate.Tracing);
+        }
+        
+        [Test]
+        public void Should_disable_tracing()
+        {
+            var vhost = managementClient.GetVhost(vhostName);
+            managementClient.DisableTracing(vhost);
+            var vhostAfterUpdate = managementClient.GetVhost(vhostName);
+            Assert.False(vhostAfterUpdate.Tracing);
+        }
     }
 }
 

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -234,6 +234,18 @@ namespace EasyNetQ.Management.Client
         void DeleteVirtualHost(Vhost vhost);
 
         /// <summary>
+        /// Enable tracing on given virtual host.
+        /// </summary>
+        /// <param name="vhost"></param>
+        void EnableTracing(Vhost vhost);
+
+        /// <summary>
+        /// Disables tracing on given virtual host.
+        /// </summary>
+        /// <param name="vhost"></param>
+        void DisableTracing(Vhost vhost);
+
+        /// <summary>
         /// Create a new user
         /// </summary>
         /// <param name="userInfo">The user to create</param>

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -423,6 +423,26 @@ namespace EasyNetQ.Management.Client
             Delete(string.Format("vhosts/{0}", vhost.Name));
         }
 
+        public void EnableTracing(Vhost vhost)
+        {
+            if (vhost == null)
+            {
+                throw new ArgumentNullException("vhost");
+            }
+            vhost.Tracing = true;
+            Put<Vhost>(string.Format("vhosts/{0}", SanitiseVhostName(vhost.Name)), vhost);
+        }
+
+        public void DisableTracing(Vhost vhost)
+        {
+            if (vhost == null)
+            {
+                throw new ArgumentNullException("vhost");
+            }
+            vhost.Tracing = false;
+            Put<Vhost>(string.Format("vhosts/{0}", SanitiseVhostName(vhost.Name)), vhost);
+        }
+
         public IEnumerable<User> GetUsers()
         {
             return Get<IEnumerable<User>>("users");


### PR DESCRIPTION
This change implements #53.
Added two new methods to management client:

EnableTracing(Vhost vhost) - to enable tracing on given virtual host
DisableTracing(Vhost vhost) - to disable.
Added two unit tests to cover added implementation.

(Same as previous PR #54 which I closed. But this one contains single commit with only related changes to #53).
