### PR TITLE
Fix consumer arguments (#65)

### DIFF
--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Model\Application.cs" />
     <Compile Include="Model\ApplyMode.cs" />
     <Compile Include="Model\Arguments.cs" />
+    <Compile Include="Model\ConsumerArguments.cs" />
     <Compile Include="Model\AuthMechanism.cs" />
     <Compile Include="Model\BackingQueueStatus.cs" />
     <Compile Include="Model\Binding.cs" />

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -32,7 +32,7 @@ namespace EasyNetQ.Management.Client.Model
 		public string ConsumerTag { get; set; }
 		public bool Exclusive { get; set; }
 		public bool AckRequired { get; set; }
-		public Arguments Arguments { get; set; }
+		public ConsumerArguments Arguments { get; set; }
         public ChannelDetail ChannelDetails { get; set; }
 	}
 

--- a/Source/EasyNetQ.Management.Client/Model/ConsumerArguments.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ConsumerArguments.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace EasyNetQ.Management.Client.Model
+{
+    public class ConsumerArguments
+    {
+        [JsonProperty(PropertyName = "x-credit")]
+        public CreditArgument Credit { get; set; }
+    }
+
+    public class CreditArgument
+    {
+        public int Credit { get; set; }
+        public bool Drain { get; set; }
+    }
+}


### PR DESCRIPTION
I've mapped the x-credit argument to a new consumer argument - I think if you are using AMQP.Net lite, these arguments will always be in the consumer. 