### PR TITLE
In some cases, channel_details is an empty array and not an object

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
@@ -224,6 +224,18 @@
             "drain": false
           }
         }
+      },
+      {
+        "channel_details": [],
+        "queue": {
+          "name": "queue_name",
+          "vhost": "/"
+        },
+        "consumer_tag": "amq.ctag-_Zd2dXucXk__XmzXwdCppg",
+        "exclusive": false,
+        "ack_required": true,
+        "prefetch_count": 1000,
+        "arguments": { }
       }
     ],
     "name": "queue_name",

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -33,6 +33,7 @@ namespace EasyNetQ.Management.Client.Model
 		public bool Exclusive { get; set; }
 		public bool AckRequired { get; set; }
 		public ConsumerArguments Arguments { get; set; }
+        [JsonConverter(typeof(ObjectOrEmptyArrayConverter<ChannelDetail>))]
         public ChannelDetail ChannelDetails { get; set; }
 	}
 


### PR DESCRIPTION
I was occasionally getting an exception when requesting queue information and noticed that in some cases "channel_details" is an empty array instead of an object.

```
 Newtonsoft.Json.JsonSerializationException : Cannot deserialize the current JSON array (e.g. [1,2,3]) into type 'EasyNetQ.Management.Client.Model.ChannelDetail' because the type requires a JSON object (e.g. {"name":"value"}) to deserialize correctly.
To fix this error either change the JSON to a JSON object (e.g. {"name":"value"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array.
Path '[2].consumer_details[1].channel_details', line 229, position 28.
Stack Trace:
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureArrayContract(JsonReader reader, Type objectType, JsonContract contract)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
```