### PR TITLE
Extend SanitiseName for additional characters

### DIFF
--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -784,7 +784,12 @@ namespace EasyNetQ.Management.Client
 
         private static string SanitiseName(string queueName)
         {
-            return queueName.Replace("+", "%2B").Replace("#", "%23").Replace("/", "%2f");
+            return queueName.Replace("+", "%2B")
+                .Replace("#", "%23")
+                .Replace("/", "%2f")
+                .Replace(":", "%3A")
+                .Replace("[", "%5B")
+                .Replace("]", "%5D");
         }
 
         private static string RecodeBindingPropertiesKey(string propertiesKey)


### PR DESCRIPTION
Deleting queues containg :, [ or ] in their names doesn't work in later RabbitMQ versions. Also see my issue I opened a few days ago about this: https://github.com/EasyNetQ/EasyNetQ.Management.Client/issues/103
