### PR TITLE
Fix for deserialization error for ConsumerArguments that were coming …

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
@@ -235,7 +235,7 @@
         "exclusive": false,
         "ack_required": true,
         "prefetch_count": 1000,
-        "arguments": { }
+        "arguments": []
       }
     ],
     "name": "queue_name",

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -32,10 +32,11 @@ namespace EasyNetQ.Management.Client.Model
 		public string ConsumerTag { get; set; }
 		public bool Exclusive { get; set; }
 		public bool AckRequired { get; set; }
-		public ConsumerArguments Arguments { get; set; }
+        [JsonConverter(typeof(ObjectOrEmptyArrayConverter<ConsumerArguments>))]
+        public ConsumerArguments Arguments { get; set; }
         [JsonConverter(typeof(ObjectOrEmptyArrayConverter<ChannelDetail>))]
         public ChannelDetail ChannelDetails { get; set; }
-	}
+    }
 
     public class ChannelDetail
     {


### PR DESCRIPTION
…back as empty array. Was calling `GetQueueAsync` and the results were:
```
"consumer_details": [
        {
            "channel_details": {
                "peer_host": "1.1.1.1",
                "peer_port": 111,
                "connection_name": "1.1.1.1:111 -> 1.1.1.2:5672",
                "user": "Removed",
                "number": 1,
                "node": "rabbit@node",
                "name": "1.1.1.1:111 -> 1.1.1.2:5672 (1)"
            },
            "arguments": [], //This was causing issues. See references below
            "prefetch_count": 3,
            "ack_required": true,
            "exclusive": false,
            "consumer_tag": "amq.ctag-blarg",
            "queue": {
                "vhost": "host",
                "name": "Queue_queue"
            }
        }, ...
```
This is similar to #95 in its impact.

RE:
https://github.com/rabbitmq/rabbitmq-management/issues/75
https://github.com/rabbitmq/rabbitmq-management/issues/424

Error this produced:
>Cannot deserialize the current JSON array (e.g. [1,2,3]) into type  'EasyNetQ.Management.Client.Model.ConsumerArguments' because the type requires a JSON object (e.g. {"name":"value"}) to deserialize correctly. To fix this error either change the JSON to a JSON object (e.g. {"name":"value"}) or change the deserialized type to an array or a type that implements a collection interface (e.g. ICollection, IList) like List<T> that can be deserialized from a JSON array. JsonArrayAttribute can also be added to the type to force it to deserialize from a JSON array. Path 'consumer_details[0].arguments', line 1, position 286.