### PR TITLE
Return IReadOnlyList instead of IEnumerable for convenience

### DIFF
--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -10,22 +10,22 @@ namespace EasyNetQ.Management.Client
     public interface IManagementClient : IDisposable
     {
         /// <summary>
-        /// The host URL that this instance is using.
+        ///     The host URL that this instance is using.
         /// </summary>
         string HostUrl { get; }
 
         /// <summary>
-        /// The Username that this instance is connecting as.
+        ///     The Username that this instance is connecting as.
         /// </summary>
         string Username { get; }
 
         /// <summary>
-        /// The port number this instance connects using.
+        ///     The port number this instance connects using.
         /// </summary>
         int PortNumber { get; }
 
         /// <summary>
-        /// Various random bits of information that describe the whole system.
+        ///     Various random bits of information that describe the whole system.
         /// </summary>
         /// <param name="lengthsCriteria">Criteria for getting samples of queue length data</param>
         /// <param name="ratesCriteria">Criteria for getting samples of rate data</param>
@@ -34,47 +34,51 @@ namespace EasyNetQ.Management.Client
         Task<Overview> GetOverviewAsync(
             GetLengthsCriteria lengthsCriteria = null,
             GetRatesCriteria ratesCriteria = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of nodes in the RabbitMQ cluster.
+        ///     A list of nodes in the RabbitMQ cluster.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Node>> GetNodesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Node>> GetNodesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// The server definitions - exchanges, queues, bindings, users, virtual hosts, permissions. 
-        /// Everything apart from messages.
+        ///     The server definitions - exchanges, queues, bindings, users, virtual hosts, permissions.
+        ///     Everything apart from messages.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<Definitions> GetDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<Definitions> GetDefinitionsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all open connections.
+        ///     A list of all open connections.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Connection>> GetConnectionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Connection>> GetConnectionsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all open channels.
+        ///     A list of all open channels.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Channel>> GetChannelsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Channel>> GetChannelsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all open channels for the given connection.
+        ///     A list of all open channels for the given connection.
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Channel>> GetChannelsAsync(Connection connection, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Channel>> GetChannelsAsync(
+            Connection connection,
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Gets the channel. This returns more detail, including consumers than the GetChannels method.
+        ///     Gets the channel. This returns more detail, including consumers than the GetChannels method.
         /// </summary>
         /// <returns>The channel.</returns>
         /// <param name="channelName">Channel name.</param>
@@ -83,76 +87,78 @@ namespace EasyNetQ.Management.Client
         Task<Channel> GetChannelAsync(
             string channelName,
             GetRatesCriteria ratesCriteria = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all exchanges.
+        ///     A list of all exchanges.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Exchange>> GetExchangesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Exchange>> GetExchangesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all queues.
+        ///     A list of all queues.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all queues for a virtual host.
+        ///     A list of all queues for a virtual host.
         /// </summary>
         /// <param name="vhost"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Queue>> GetQueuesAsync(Vhost vhost, CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Queue>> GetQueuesAsync(Vhost vhost, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all bindings.
+        ///     A list of all bindings.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Binding>> GetBindingsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Binding>> GetBindingsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all vhosts.
+        ///     A list of all vhosts.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Vhost>> GetVhostsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Vhost>> GetVhostsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all users.
+        ///     A list of all users.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<User>> GetUsersAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<User>> GetUsersAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all permissions for all users.
+        ///     A list of all permissions for all users.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Permission>> GetPermissionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Permission>> GetPermissionsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// A list of all topic permissions for all users.
+        ///     A list of all topic permissions for all users.
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<TopicPermission>> GetTopicPermissionsAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<TopicPermission>> GetTopicPermissionsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Closes the given connection
+        ///     Closes the given connection
         /// </summary>
         /// <param name="connection"></param>
         /// <param name="cancellationToken"></param>
         Task CloseConnectionAsync(
             [NotNull] Connection connection,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Creates the given exchange
+        ///     Creates the given exchange
         /// </summary>
         /// <param name="exchangeInfo"></param>
         /// <param name="vhost"></param>
@@ -160,43 +166,46 @@ namespace EasyNetQ.Management.Client
         Task<Exchange> CreateExchangeAsync(
             [NotNull] ExchangeInfo exchangeInfo,
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete the given exchange
+        ///     Delete the given exchange
         /// </summary>
         /// <param name="exchange"></param>
         /// <param name="cancellationToken"></param>
         Task DeleteExchangeAsync(
             [NotNull] Exchange exchange,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all bindings in which a given exchange is the source.
+        ///     A list of all bindings in which a given exchange is the source.
         /// </summary>
         /// <param name="exchange"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Binding>> GetBindingsWithSourceAsync(
+        Task<IReadOnlyList<Binding>> GetBindingsWithSourceAsync(
             [NotNull] Exchange exchange,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all bindings in which a given exchange is the destination.
+        ///     A list of all bindings in which a given exchange is the destination.
         /// </summary>
         /// <param name="exchange"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Binding>> GetBindingsWithDestinationAsync(
+        Task<IReadOnlyList<Binding>> GetBindingsWithDestinationAsync(
             [NotNull] Exchange exchange,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Publish a message to a given exchange.
-        /// 
-        /// Please note that the publish / get paths in the HTTP API are intended for injecting 
-        /// test messages, diagnostics etc - they do not implement reliable delivery and so should 
-        /// be treated as a sysadmin's tool rather than a general API for messaging.
+        ///     Publish a message to a given exchange.
+        ///     Please note that the publish / get paths in the HTTP API are intended for injecting
+        ///     test messages, diagnostics etc - they do not implement reliable delivery and so should
+        ///     be treated as a sysadmin's tool rather than a general API for messaging.
         /// </summary>
         /// <param name="exchange">The exchange</param>
         /// <param name="publishInfo">The publication parameters</param>
@@ -205,10 +214,11 @@ namespace EasyNetQ.Management.Client
         Task<PublishResult> PublishAsync(
             [NotNull] Exchange exchange,
             [NotNull] PublishInfo publishInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create the given queue
+        ///     Create the given queue
         /// </summary>
         /// <param name="queueInfo"></param>
         /// <param name="vhost"></param>
@@ -216,54 +226,58 @@ namespace EasyNetQ.Management.Client
         Task<Queue> CreateQueueAsync(
             [NotNull] QueueInfo queueInfo,
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete the given queue
+        ///     Delete the given queue
         /// </summary>
         /// <param name="queue"></param>
         /// <param name="cancellationToken"></param>
         Task DeleteQueueAsync(
             [NotNull] Queue queue,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all bindings on a given queue.
+        ///     A list of all bindings on a given queue.
         /// </summary>
         /// <param name="queue"></param>
         /// <param name="cancellationToken"></param>
-        Task<IEnumerable<Binding>> GetBindingsForQueueAsync(
+        Task<IReadOnlyList<Binding>> GetBindingsForQueueAsync(
             [NotNull] Queue queue,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Purge a queue of all messages
+        ///     Purge a queue of all messages
         /// </summary>
         /// <param name="queue"></param>
         /// <param name="cancellationToken"></param>
         Task PurgeAsync(
             [NotNull] Queue queue,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get messages from a queue.
-        /// 
-        /// Please note that the publish / get paths in the HTTP API are intended for 
-        /// injecting test messages, diagnostics etc - they do not implement reliable 
-        /// delivery and so should be treated as a sysadmin's tool rather than a 
-        /// general API for messaging.
+        ///     Get messages from a queue.
+        ///     Please note that the publish / get paths in the HTTP API are intended for
+        ///     injecting test messages, diagnostics etc - they do not implement reliable
+        ///     delivery and so should be treated as a sysadmin's tool rather than a
+        ///     general API for messaging.
         /// </summary>
         /// <param name="queue">The queue to retrieve from</param>
         /// <param name="criteria">The criteria for the retrieve</param>
         /// <param name="cancellationToken"></param>
         /// <returns>Messages</returns>
-        Task<IEnumerable<Message>> GetMessagesFromQueueAsync(
+        Task<IReadOnlyList<Message>> GetMessagesFromQueueAsync(
             [NotNull] Queue queue,
             GetMessagesCriteria criteria,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a binding between an exchange and a queue
+        ///     Create a binding between an exchange and a queue
         /// </summary>
         /// <param name="exchange">the exchange</param>
         /// <param name="queue">the queue</param>
@@ -274,10 +288,11 @@ namespace EasyNetQ.Management.Client
             [NotNull] Exchange exchange,
             [NotNull] Queue queue,
             [NotNull] BindingInfo bindingInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a binding between an exchange and an exchange
+        ///     Create a binding between an exchange and an exchange
         /// </summary>
         /// <param name="sourceExchange">the source exchange</param>
         /// <param name="destinationExchange">the destination exchange</param>
@@ -287,134 +302,148 @@ namespace EasyNetQ.Management.Client
             [NotNull] Exchange sourceExchange,
             [NotNull] Exchange destinationExchange,
             [NotNull] BindingInfo bindingInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all bindings between an exchange and a queue. 
-        /// Remember, an exchange and a queue can be bound together many times!
+        ///     A list of all bindings between an exchange and a queue.
+        ///     Remember, an exchange and a queue can be bound together many times!
         /// </summary>
         /// <param name="exchange"></param>
         /// <param name="queue"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Binding>> GetBindingsAsync(
+        Task<IReadOnlyList<Binding>> GetBindingsAsync(
             [NotNull] Exchange exchange,
             [NotNull] Queue queue,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// A list of all bindings between an exchange and an exchange. 
+        ///     A list of all bindings between an exchange and an exchange.
         /// </summary>
         /// <param name="fromExchange"></param>
         /// <param name="toExchange"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IEnumerable<Binding>> GetBindingsAsync(
+        Task<IReadOnlyList<Binding>> GetBindingsAsync(
             [NotNull] Exchange fromExchange,
             [NotNull] Exchange toExchange,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete the given binding
+        ///     Delete the given binding
         /// </summary>
         /// <param name="binding"></param>
         /// <param name="cancellationToken"></param>
         Task DeleteBindingAsync(
             [NotNull] Binding binding,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a new virtual host
+        ///     Create a new virtual host
         /// </summary>
         /// <param name="vhostName">The name of the new virtual host</param>
         /// <param name="cancellationToken"></param>
         Task<Vhost> CreateVhostAsync(
             string vhostName,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a virtual host
+        ///     Delete a virtual host
         /// </summary>
         /// <param name="vhost">The virtual host to delete</param>
         /// <param name="cancellationToken"></param>
         Task DeleteVhostAsync(
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Enable tracing on given virtual host.
+        ///     Enable tracing on given virtual host.
         /// </summary>
         /// <param name="vhost">The virtual host on which to enable tracing</param>
         /// <param name="cancellationToken"></param>
         Task EnableTracingAsync(
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Disables tracing on given virtual host.
+        ///     Disables tracing on given virtual host.
         /// </summary>
         /// <param name="vhost">The virtual host on which to disable tracing</param>
         /// <param name="cancellationToken"></param>
         Task DisableTracingAsync(
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a new user
+        ///     Create a new user
         /// </summary>
         /// <param name="userInfo">The user to create</param>
         /// <param name="cancellationToken"></param>
         Task<User> CreateUserAsync(
             [NotNull] UserInfo userInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a user
+        ///     Delete a user
         /// </summary>
         /// <param name="user">The user to delete</param>
         /// <param name="cancellationToken"></param>
         Task DeleteUserAsync(
             [NotNull] User user,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a permission
+        ///     Create a permission
         /// </summary>
         /// <param name="permissionInfo">The permission to create</param>
         /// <param name="cancellationToken"></param>
         Task CreatePermissionAsync(
             [NotNull] PermissionInfo permissionInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a permission
+        ///     Delete a permission
         /// </summary>
         /// <param name="permission">The permission to delete</param>
         /// <param name="cancellationToken"></param>
         Task DeletePermissionAsync(
             [NotNull] Permission permission,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Create a topic permission
+        ///     Create a topic permission
         /// </summary>
         /// <param name="topicPermissionInfo">The topic permission to create</param>
         /// <param name="cancellationToken"></param>
         Task CreateTopicPermissionAsync(
             [NotNull] TopicPermissionInfo topicPermissionInfo,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a topic permission
+        ///     Delete a topic permission
         /// </summary>
         /// <param name="permission">The topic permission to delete</param>
         /// <param name="cancellationToken"></param>
         Task DeleteTopicPermissionAsync(
             [NotNull] TopicPermission permission,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Update the password of an user.
+        ///     Update the password of an user.
         /// </summary>
         /// <param name="userName">The name of a user</param>
         /// <param name="newPassword">The new password to set</param>
@@ -422,23 +451,25 @@ namespace EasyNetQ.Management.Client
         Task<User> ChangeUserPasswordAsync(
             string userName,
             string newPassword,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
-        
+
         /// <summary>
-        /// Declares a test queue, then publishes and consumes a message. Intended for use 
-        /// by monitoring tools. If everything is working correctly, will return true.
-        /// Note: the test queue will not be deleted (to to prevent queue churn if this 
-        /// is repeatedly pinged).
+        ///     Declares a test queue, then publishes and consumes a message. Intended for use
+        ///     by monitoring tools. If everything is working correctly, will return true.
+        ///     Note: the test queue will not be deleted (to to prevent queue churn if this
+        ///     is repeatedly pinged).
         /// </summary>
         /// <param name="vhost"></param>
         /// <param name="cancellationToken"></param>
         Task<bool> IsAliveAsync(
             [NotNull] Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get an individual exchange by name
+        ///     Get an individual exchange by name
         /// </summary>
         /// <param name="exchangeName">The name of the exchange</param>
         /// <param name="vhost">The virtual host that contains the exchange</param>
@@ -449,10 +480,11 @@ namespace EasyNetQ.Management.Client
             string exchangeName,
             [NotNull] Vhost vhost,
             GetRatesCriteria ratesCriteria = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get an individual queue by name
+        ///     Get an individual queue by name
         /// </summary>
         /// <param name="queueName">The name of the queue</param>
         /// <param name="vhost">The virtual host that contains the queue</param>
@@ -465,45 +497,49 @@ namespace EasyNetQ.Management.Client
             [NotNull] Vhost vhost,
             GetLengthsCriteria lengthsCriteria = null,
             GetRatesCriteria ratesCriteria = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get an individual vhost by name
+        ///     Get an individual vhost by name
         /// </summary>
         /// <param name="vhostName">The VHost</param>
         /// <param name="cancellationToken"></param>
         Task<Vhost> GetVhostAsync(
             string vhostName,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get a user by name
+        ///     Get a user by name
         /// </summary>
         /// <param name="userName">The name of the user</param>
         /// <param name="cancellationToken"></param>
         /// <returns>The User</returns>
         Task<User> GetUserAsync(
             string userName,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get collection of Policies on the cluster
+        ///     Get collection of Policies on the cluster
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns>Policies</returns>
-        Task<IEnumerable<Policy>> GetPoliciesAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Policy>> GetPoliciesAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a policy on the cluster
+        ///     Creates a policy on the cluster
         /// </summary>
         /// <param name="policy">Policy to create</param>
         /// <param name="cancellationToken"></param>
         Task CreatePolicyAsync(
             [NotNull] Policy policy,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a policy from the cluster
+        ///     Delete a policy from the cluster
         /// </summary>
         /// <param name="policyName">Policy name</param>
         /// <param name="vhost">vhost on which the policy resides</param>
@@ -511,25 +547,27 @@ namespace EasyNetQ.Management.Client
         Task DeletePolicyAsync(
             string policyName,
             Vhost vhost,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get all parameters on the cluster
+        ///     Get all parameters on the cluster
         /// </summary>
         /// <param name="cancellationToken"></param>
-        Task<IEnumerable<Parameter>> GetParametersAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<IReadOnlyList<Parameter>> GetParametersAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Creates a parameter on the cluster
+        ///     Creates a parameter on the cluster
         /// </summary>
         /// <param name="parameter">Parameter to create</param>
         /// <param name="cancellationToken"></param>
         Task CreateParameterAsync(
-            [NotNull]Parameter parameter,
-            CancellationToken cancellationToken = default(CancellationToken));
+            [NotNull] Parameter parameter,
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Delete a parameter from the cluster
+        ///     Delete a parameter from the cluster
         /// </summary>
         /// <param name="componentName"></param>
         /// <param name="vhostName"></param>
@@ -539,13 +577,14 @@ namespace EasyNetQ.Management.Client
             string componentName,
             string vhostName,
             string name,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
-        /// Get list of federations
+        ///     Get list of federations
         /// </summary>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<List<Federation>> GetFederationAsync(CancellationToken cancellationToken = default(CancellationToken));
+        Task<List<Federation>> GetFederationAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -18,7 +18,7 @@ namespace EasyNetQ.Management.Client
     public class ManagementClient : IManagementClient
     {
         private static readonly Regex ParameterNameRegex = new Regex("([a-z])([A-Z])", RegexOptions.Compiled);
-        
+
         private static Task CompletedTask { get; } = Task.FromResult<object>(null);
 
         private static readonly MediaTypeWithQualityHeaderValue JsonMediaTypeHeaderValue =
@@ -143,15 +143,15 @@ namespace EasyNetQ.Management.Client
             GetRatesCriteria ratesCriteria = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             var queryParameters = MergeQueryParameters(
-                lengthsCriteria?.ToQueryParameters(), 
+                lengthsCriteria?.ToQueryParameters(),
                 ratesCriteria?.ToQueryParameters()
             );
             return GetAsync<Overview>("overview", queryParameters, cancellationToken);
         }
 
-        public Task<IEnumerable<Node>> GetNodesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public Task<IReadOnlyList<Node>> GetNodesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Node>>("nodes", cancellationToken);
+            return GetAsync<IReadOnlyList<Node>>("nodes", cancellationToken);
         }
 
         public Task<Definitions> GetDefinitionsAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -159,10 +159,10 @@ namespace EasyNetQ.Management.Client
             return GetAsync<Definitions>("definitions", cancellationToken);
         }
 
-        public Task<IEnumerable<Connection>> GetConnectionsAsync(
+        public Task<IReadOnlyList<Connection>> GetConnectionsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Connection>>("connections", cancellationToken);
+            return GetAsync<IReadOnlyList<Connection>>("connections", cancellationToken);
         }
 
         public Task CloseConnectionAsync(Connection connection,
@@ -172,17 +172,17 @@ namespace EasyNetQ.Management.Client
             return DeleteAsync($"connections/{connection.Name}", cancellationToken);
         }
 
-        public Task<IEnumerable<Channel>> GetChannelsAsync(
+        public Task<IReadOnlyList<Channel>> GetChannelsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Channel>>("channels", cancellationToken);
+            return GetAsync<IReadOnlyList<Channel>>("channels", cancellationToken);
         }
 
-        public Task<IEnumerable<Channel>> GetChannelsAsync(
+        public Task<IReadOnlyList<Channel>> GetChannelsAsync(
             Connection connection,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Channel>>($"connections/{connection.Name}/channels", cancellationToken);
+            return GetAsync<IReadOnlyList<Channel>>($"connections/{connection.Name}/channels", cancellationToken);
         }
 
         public Task<Channel> GetChannelAsync(string channelName, GetRatesCriteria ratesCriteria = null,
@@ -193,10 +193,10 @@ namespace EasyNetQ.Management.Client
             return GetAsync<Channel>($"channels/{channelName}", ratesCriteria?.ToQueryParameters(), cancellationToken);
         }
 
-        public Task<IEnumerable<Exchange>> GetExchangesAsync(
+        public Task<IReadOnlyList<Exchange>> GetExchangesAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Exchange>>("exchanges", cancellationToken);
+            return GetAsync<IReadOnlyList<Exchange>>("exchanges", cancellationToken);
         }
 
         public Task<Exchange> GetExchangeAsync(string exchangeName, Vhost vhost, GetRatesCriteria ratesCriteria = null,
@@ -213,9 +213,9 @@ namespace EasyNetQ.Management.Client
         {
             Ensure.ArgumentNotNull(queueName, nameof(queueName));
             Ensure.ArgumentNotNull(vhost, nameof(vhost));
-            
+
             var queryParameters = MergeQueryParameters(
-                lengthsCriteria?.ToQueryParameters(), 
+                lengthsCriteria?.ToQueryParameters(),
                 ratesCriteria?.ToQueryParameters()
             );
             return GetAsync<Queue>($"queues/{SanitiseVhostName(vhost.Name)}/{SanitiseName(queueName)}",
@@ -244,21 +244,21 @@ namespace EasyNetQ.Management.Client
                 cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsWithSourceAsync(Exchange exchange,
+        public Task<IReadOnlyList<Binding>> GetBindingsWithSourceAsync(Exchange exchange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(exchange, nameof(exchange));
 
-            return GetAsync<IEnumerable<Binding>>(
+            return GetAsync<IReadOnlyList<Binding>>(
                 $"exchanges/{SanitiseVhostName(exchange.Vhost)}/{exchange.Name}/bindings/source", cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsWithDestinationAsync(Exchange exchange,
+        public Task<IReadOnlyList<Binding>> GetBindingsWithDestinationAsync(Exchange exchange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(exchange, nameof(exchange));
 
-            return GetAsync<IEnumerable<Binding>>(
+            return GetAsync<IReadOnlyList<Binding>>(
                 $"exchanges/{SanitiseVhostName(exchange.Vhost)}/{exchange.Name}/bindings/destination",
                 cancellationToken);
         }
@@ -274,14 +274,14 @@ namespace EasyNetQ.Management.Client
                 cancellationToken);
         }
 
-        public Task<IEnumerable<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public Task<IReadOnlyList<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Queue>>("queues", cancellationToken);
+            return GetAsync<IReadOnlyList<Queue>>("queues", cancellationToken);
         }
 
-        public Task<IEnumerable<Queue>> GetQueuesAsync(Vhost vhost, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<IReadOnlyList<Queue>> GetQueuesAsync(Vhost vhost, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Queue>>($"queues/{SanitiseVhostName(vhost.Name)}", cancellationToken);
+            return GetAsync<IReadOnlyList<Queue>>($"queues/{SanitiseVhostName(vhost.Name)}", cancellationToken);
         }
 
         public async Task<Queue> CreateQueueAsync(QueueInfo queueInfo, Vhost vhost,
@@ -306,12 +306,12 @@ namespace EasyNetQ.Management.Client
                 cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsForQueueAsync(Queue queue,
+        public Task<IReadOnlyList<Binding>> GetBindingsForQueueAsync(Queue queue,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(queue, nameof(queue));
 
-            return GetAsync<IEnumerable<Binding>>(
+            return GetAsync<IReadOnlyList<Binding>>(
                 $"queues/{SanitiseVhostName(queue.Vhost)}/{SanitiseName(queue.Name)}/bindings", cancellationToken);
         }
 
@@ -323,19 +323,19 @@ namespace EasyNetQ.Management.Client
                 cancellationToken);
         }
 
-        public Task<IEnumerable<Message>> GetMessagesFromQueueAsync(Queue queue, GetMessagesCriteria criteria,
+        public Task<IReadOnlyList<Message>> GetMessagesFromQueueAsync(Queue queue, GetMessagesCriteria criteria,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(queue, nameof(queue));
 
-            return PostAsync<GetMessagesCriteria, IEnumerable<Message>>(
+            return PostAsync<GetMessagesCriteria, IReadOnlyList<Message>>(
                 $"queues/{SanitiseVhostName(queue.Vhost)}/{SanitiseName(queue.Name)}/get", criteria, cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsAsync(
+        public Task<IReadOnlyList<Binding>> GetBindingsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Binding>>("bindings", cancellationToken);
+            return GetAsync<IReadOnlyList<Binding>>("bindings", cancellationToken);
         }
 
         public Task CreateBindingAsync(Exchange exchange, Queue queue, BindingInfo bindingInfo,
@@ -362,24 +362,24 @@ namespace EasyNetQ.Management.Client
                 bindingInfo, cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsAsync(Exchange exchange, Queue queue,
+        public Task<IReadOnlyList<Binding>> GetBindingsAsync(Exchange exchange, Queue queue,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(exchange, nameof(exchange));
             Ensure.ArgumentNotNull(queue, nameof(queue));
 
-            return GetAsync<IEnumerable<Binding>>(
+            return GetAsync<IReadOnlyList<Binding>>(
                 $"bindings/{SanitiseVhostName(queue.Vhost)}/e/{exchange.Name}/q/{SanitiseName(queue.Name)}",
                 cancellationToken);
         }
 
-        public Task<IEnumerable<Binding>> GetBindingsAsync(Exchange fromExchange, Exchange toExchange,
+        public Task<IReadOnlyList<Binding>> GetBindingsAsync(Exchange fromExchange, Exchange toExchange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Ensure.ArgumentNotNull(fromExchange, nameof(fromExchange));
             Ensure.ArgumentNotNull(toExchange, nameof(toExchange));
 
-            return GetAsync<IEnumerable<Binding>>(
+            return GetAsync<IReadOnlyList<Binding>>(
                 $"bindings/{SanitiseVhostName(toExchange.Vhost)}/e/{fromExchange.Name}/e/{SanitiseName(toExchange.Name)}",
                 cancellationToken);
         }
@@ -412,9 +412,9 @@ namespace EasyNetQ.Management.Client
                 RecodeBindingPropertiesKey(binding.PropertiesKey)), cancellationToken);
         }
 
-        public Task<IEnumerable<Vhost>> GetVhostsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public Task<IReadOnlyList<Vhost>> GetVhostsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Vhost>>("vhosts", cancellationToken);
+            return GetAsync<IReadOnlyList<Vhost>>("vhosts", cancellationToken);
         }
 
         public Task<Vhost> GetVhostAsync(string vhostName,
@@ -457,9 +457,9 @@ namespace EasyNetQ.Management.Client
             return PutAsync<Vhost>($"vhosts/{SanitiseVhostName(vhost.Name)}", vhost, cancellationToken);
         }
 
-        public Task<IEnumerable<User>> GetUsersAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public Task<IReadOnlyList<User>> GetUsersAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<User>>("users", cancellationToken);
+            return GetAsync<IReadOnlyList<User>>("users", cancellationToken);
         }
 
         public Task<User> GetUserAsync(string userName,
@@ -469,10 +469,10 @@ namespace EasyNetQ.Management.Client
             return GetAsync<User>($"users/{userName}", cancellationToken);
         }
 
-        public Task<IEnumerable<Policy>> GetPoliciesAsync(
+        public Task<IReadOnlyList<Policy>> GetPoliciesAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Policy>>("policies", cancellationToken);
+            return GetAsync<IReadOnlyList<Policy>>("policies", cancellationToken);
         }
 
         public Task CreatePolicyAsync(Policy policy, CancellationToken cancellationToken = default(CancellationToken))
@@ -505,10 +505,10 @@ namespace EasyNetQ.Management.Client
             return DeleteAsync(GetPolicyUrl(policyName, vhost.Name), cancellationToken);
         }
 
-        public Task<IEnumerable<Parameter>> GetParametersAsync(
+        public Task<IReadOnlyList<Parameter>> GetParametersAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Parameter>>("parameters", cancellationToken);
+            return GetAsync<IReadOnlyList<Parameter>>("parameters", cancellationToken);
         }
 
         public Task CreateParameterAsync(Parameter parameter,
@@ -546,10 +546,10 @@ namespace EasyNetQ.Management.Client
             return DeleteAsync($"users/{user.Name}", cancellationToken);
         }
 
-        public Task<IEnumerable<Permission>> GetPermissionsAsync(
+        public Task<IReadOnlyList<Permission>> GetPermissionsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<Permission>>("permissions", cancellationToken);
+            return GetAsync<IReadOnlyList<Permission>>("permissions", cancellationToken);
         }
 
         public Task CreatePermissionAsync(PermissionInfo permissionInfo,
@@ -570,10 +570,10 @@ namespace EasyNetQ.Management.Client
             return DeleteAsync($"permissions/{permission.Vhost}/{permission.User}", cancellationToken);
         }
 
-        public Task<IEnumerable<TopicPermission>> GetTopicPermissionsAsync(
+        public Task<IReadOnlyList<TopicPermission>> GetTopicPermissionsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetAsync<IEnumerable<TopicPermission>>("topic-permissions", cancellationToken);
+            return GetAsync<IReadOnlyList<TopicPermission>>("topic-permissions", cancellationToken);
         }
 
         public Task CreateTopicPermissionAsync(TopicPermissionInfo topicPermissionInfo,


### PR DESCRIPTION
:-/

For instance,

```
var connections = await client.GetConnectionsAsync(cancellationToken).ConfigureAwait(false);
```

if I need to check connections count I have to materialize enumerable(with ToList or ToArray) to not have "Possible multiple enumeration" warning. Also, under the hood, there is no laziness of loading any data and it's fine to return Array or List.
