### PR TITLE
Implemented GetConsumersAsync method, with serialization test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Appveyor build status](https://ci.appveyor.com/api/projects/status/s3a158jwtxgwco90/branch/master?svg=true)](https://ci.appveyor.com/api/projects/status/s3a158jwtxgwco90/branch/master)
-[![Travis build Status](https://travis-ci.org/EasyNetQ/EasyNetQ.Management.Client.svg?branch=master)](https://travis-ci.org/EasyNetQ/EasyNetQ.Management.Client)
+[![Travis build Status](https://travis-ci.com/EasyNetQ/EasyNetQ.Management.Client.svg?branch=master)](https://travis-ci.com/EasyNetQ/EasyNetQ.Management.Client)
 ----------
 
 ## EasyNetQ.Management.Client

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -920,6 +920,18 @@ namespace EasyNetQ.Management.Client.IntegrationTests
             }
         }
 
+        [Fact(Skip = "Requires at least a consumer")]
+        public async Task Should_get_consumers()
+        {
+            foreach (var consumer in await managementClient.GetConsumersAsync().ConfigureAwait(false))
+            {
+                Console.Out.WriteLine("consumer.ConsumerTag = {0}", consumer.ConsumerTag);
+                Console.Out.WriteLine("consumer.ChannelDetails.ConnectionName = {0}", consumer.ChannelDetails.ConnectionName);
+                Console.Out.WriteLine("consumer.ChannelDetails.ConnectionName = {0}", consumer.ChannelDetails.ConnectionName);
+                Console.Out.WriteLine("consumer.ChannelDetails.Node = {0}", consumer.ChannelDetails.Node);
+            }
+        }
+
         [Fact]
         public async Task Should_get_channels()
         {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/RabbitMqFixture.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/RabbitMqFixture.cs
@@ -17,7 +17,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
     public class RabbitMqFixture : IAsyncLifetime, IDisposable
     {
-        private static readonly TimeSpan InitializationTimeout = TimeSpan.FromMinutes(2);
+        private static readonly TimeSpan InitializationTimeout = TimeSpan.FromMinutes(10);
 
         private readonly DockerProxy dockerProxy;
         private OSPlatform dockerEngineOsPlatform;

--- a/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
+++ b/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
@@ -9,6 +9,7 @@
     <None Remove="Json\Bindings.json" />
     <None Remove="Json\Channels.json" />
     <None Remove="Json\Connections.json" />
+    <None Remove="Json\Consumers.json" />
     <None Remove="Json\Definitions.json" />
     <None Remove="Json\Exchanges.json" />
     <None Remove="Json\Federations.json" />
@@ -19,6 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="Json\Consumers.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="Json\Bindings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>

--- a/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
+++ b/Source/EasyNetQ.Management.Client.Tests/EasyNetQ.Management.Client.Tests.csproj
@@ -6,51 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Json\Bindings.json" />
-    <None Remove="Json\Channels.json" />
-    <None Remove="Json\Connections.json" />
-    <None Remove="Json\Consumers.json" />
-    <None Remove="Json\Definitions.json" />
-    <None Remove="Json\Exchanges.json" />
-    <None Remove="Json\Federations.json" />
-    <None Remove="Json\Nodes.json" />
-    <None Remove="Json\Overview.json" />
-    <None Remove="Json\Policies_ha.json" />
-    <None Remove="Json\Queues.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Json\Consumers.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Bindings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Channels.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Connections.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Definitions.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Exchanges.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Federations.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Nodes.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Overview.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Policies_ha.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Json\Queues.json">
+    <EmbeddedResource Include="Json\*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>

--- a/Source/EasyNetQ.Management.Client.Tests/Json/Consumers.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Consumers.json
@@ -1,0 +1,77 @@
+﻿[
+  {
+    "arguments": {
+      "x-cancel-on-ha-failover": false,
+      "x-priority": 0
+    },
+    "ack_required": true,
+    "active": true,
+    "activity_status": "up",
+    "channel_details": {
+      "connection_name": "[::1]:65216 -> [::1]:5672",
+      "name": "[::1]:65216 -> [::1]:5672 (4)",
+      "node": "rabbit@LOCALHOST",
+      "number": 4,
+      "peer_host": "::1",
+      "peer_port": 65216,
+      "user": "guest"
+    },
+    "consumer_tag": "60479aa8-c8b8-43d1-baee-e45731b53024",
+    "exclusive": false,
+    "prefetch_count": 50,
+    "queue": {
+      "name": "Queue01",
+      "vhost": "/"
+    }
+  },
+  {
+    "arguments": {
+      "x-cancel-on-ha-failover": false,
+      "x-priority": 0
+    },
+    "ack_required": true,
+    "active": true,
+    "activity_status": "up",
+    "channel_details": {
+      "connection_name": "[::1]:65216 -> [::1]:5672",
+      "name": "[::1]:65216 -> [::1]:5672 (3)",
+      "node": "rabbit@LOCALHOST",
+      "number": 3,
+      "peer_host": "::1",
+      "peer_port": 65216,
+      "user": "guest"
+    },
+    "consumer_tag": "90479aa8-c8b8-43d1-baee-e45731b53111",
+    "exclusive": false,
+    "prefetch_count": 50,
+    "queue": {
+      "name": "Queue02",
+      "vhost": "/"
+    }
+  },
+  {
+    "arguments": {
+      "x-cancel-on-ha-failover": false,
+      "x-priority": 0
+    },
+    "ack_required": true,
+    "active": true,
+    "activity_status": "up",
+    "channel_details": {
+      "connection_name": "[::1]:65216 -> [::1]:5672",
+      "name": "[::1]:65216 -> [::1]:5672 (1)",
+      "node": "rabbit@LOCALHOST",
+      "number": 1,
+      "peer_host": "::1",
+      "peer_port": 65216,
+      "user": "guest"
+    },
+    "consumer_tag": "123459aa8-c8b8-43d1-baee-e45731b53024",
+    "exclusive": false,
+    "prefetch_count": 50,
+    "queue": {
+      "name": "Queue03",
+      "vhost": "/"
+    }
+  }
+]

--- a/Source/EasyNetQ.Management.Client.Tests/Model/ConsumerSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/ConsumerSerializationTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using EasyNetQ.Management.Client.Model;
+using FluentAssertions;
+using Xunit;
+
+namespace EasyNetQ.Management.Client.Tests.Model
+{
+    public class ConsumerSerializationTests
+    {
+        private readonly List<Consumer> consumers;
+
+        public ConsumerSerializationTests()
+        {
+            consumers = ResourceLoader.LoadObjectFromJson<List<Consumer>>("Consumers.json");
+        }
+
+        [Fact]
+        public void Should_load_three_consumers()
+        {
+            consumers.Count.Should().Be(3);
+        }
+
+        [Fact]
+        public void Should_have_consumer_properties()
+        {
+            var consumer = consumers[0];
+
+            consumer.Queue.Name.Should().Be("Queue01");
+            consumer.ChannelDetails.Node.Should().Be("rabbit@LOCALHOST");
+        }
+    }
+}
+
+// ReSharper restore InconsistentNaming

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -148,6 +148,13 @@ namespace EasyNetQ.Management.Client
         Task<IReadOnlyList<TopicPermission>> GetTopicPermissionsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
+        ///     A list of all consumers.
+        /// </summary>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<IReadOnlyList<Consumer>> GetConsumersAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
         ///     Closes the given connection
         /// </summary>
         /// <param name="connection"></param>

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -849,5 +849,9 @@ namespace EasyNetQ.Management.Client
         {
             httpClient.Dispose();
         }
+        public Task<IReadOnlyList<Consumer>> GetConsumersAsync(CancellationToken cancellationToken = default)
+        {
+            return GetAsync<IReadOnlyList<Consumer>>("consumers", cancellationToken);
+        }
     }
 }

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -849,7 +849,9 @@ namespace EasyNetQ.Management.Client
         {
             httpClient.Dispose();
         }
+
         public Task<IReadOnlyList<Consumer>> GetConsumersAsync(CancellationToken cancellationToken = default)
+
         {
             return GetAsync<IReadOnlyList<Consumer>>("consumers", cancellationToken);
         }

--- a/Source/EasyNetQ.Management.Client/Model/Channel.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Channel.cs
@@ -47,5 +47,6 @@ namespace EasyNetQ.Management.Client.Model
         [JsonConverter(typeof(TolerantInt32Converter))]
         public int PeerPort { get; set; }
         public string PeerHost { get; set; }
+        public string Node { get; set; }
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Consumer.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Consumer.cs
@@ -1,0 +1,15 @@
+﻿namespace EasyNetQ.Management.Client.Model
+{
+    public class Consumer
+    {
+        public Arguments Arguments { get; set; }
+        public bool AckRequired { get; set;}
+        public bool Active { get; set; }
+        public string ActivityStatus { get; set; }
+        public ChannelDetail ChannelDetails { get; set; }
+        public string ConsumerTag { get; set; }
+        public bool Exclusive { get; set; }
+        public int PrefetchCount { get; set; }
+        public QueueName Queue { get; set; }
+    }
+}

--- a/Source/EasyNetQ.Management.Client/Model/QueueName.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueName.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace EasyNetQ.Management.Client.Model
+{
+    public class QueueName
+    {
+        public string Name { get; set; }
+        public string VHost { get; set; }
+    }
+}


### PR DESCRIPTION
Implemented `GetConsumersAsync` method, with serialization test
Implemented `Consumer` and `QueueName` classes

Testing EasyNetQ.Management.Client v.1.3.0 on RabbitMq 3.8.* shows property `ConsumerDetails` from `Channel` and `Queue` types always returns null, since that property is no longer present in the returned JSON. Consumers must be now retrieved from proper route `consumers`, which is reached by the implemented method