### PR TITLE
Chage user model Tags to be a list

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/Configuration.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/Configuration.cs
@@ -69,7 +69,8 @@ namespace EasyNetQ.Management.Client.IntegrationTests
 
         public static string RabbitMQDockerImageTag(OSPlatform dockerEngineOsPlatform)
         {
-            return Instance.osSpecificSettings[dockerEngineOsPlatform]["rabbitMQDockerImageTag"];
+            return "latest";
+            //return Instance.osSpecificSettings[dockerEngineOsPlatform]["rabbitMQDockerImageTag"];
         }
     }
 }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -78,7 +78,7 @@ namespace EasyNetQ.Management.Client.IntegrationTests
                 .ConfigureAwait(false);
 
             updatedUser.Name.Should().Be(user.Name);
-            updatedUser.Tags.Should().Be(user.Tags);
+            updatedUser.Tags.SequenceEqual(user.Tags).Should().BeTrue();
             updatedUser.PasswordHash.Should().NotBe(user.PasswordHash);
         }
 

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -600,9 +600,8 @@ namespace EasyNetQ.Management.Client
             Ensure.ArgumentNotNull(userName, nameof(userName));
             var user = await GetUserAsync(userName, cancellationToken).ConfigureAwait(false);
 
-            var tags = user.Tags.Split(',');
             var userInfo = new UserInfo(userName, newPassword);
-            foreach (var tag in tags)
+            foreach (var tag in user.Tags)
             {
                 userInfo.AddTag(tag.Trim());
             }

--- a/Source/EasyNetQ.Management.Client/Model/User.cs
+++ b/Source/EasyNetQ.Management.Client/Model/User.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
+
 namespace EasyNetQ.Management.Client.Model
 {
     public class User
     {
         public string Name { get; set; }
         public string PasswordHash { get; set; }
-        public string Tags { get; set; }
+        public IList<string> Tags { get; set; }
     }
 }


### PR DESCRIPTION
Change the model of User to use a list of string instead of a single string for Tags.
RabbitMq api returns a list of tags instead of comma separated values