### PR TITLE
Fix deprecation warnings in tests

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -86,7 +86,7 @@ public class ManagementClientTests
     public async Task Should_be_able_to_configure_request()
     {
         using var client = new ManagementClient(
-            fixture.Host, fixture.User, fixture.Password, configureHttpRequestMessage: req => req.Headers.Add("x-not-used", "some_value")
+            fixture.Endpoint, fixture.User, fixture.Password, configureHttpRequestMessage: req => req.Headers.Add("x-not-used", "some_value")
         );
 
         await client.GetOverviewAsync();
@@ -446,7 +446,7 @@ public class ManagementClientTests
             Component = "federation-upstream",
             Name = "myfakefederationupstream1",
             Vhost = Vhost.Name,
-            Value = new { Uri = $"amqp://{fixture.User}:{fixture.Password}@{fixture.Host}" }
+            Value = new { Uri = $"amqp://{fixture.User}:{fixture.Password}@{fixture.Endpoint.Host}" }
         });
         Assert.Contains(await fixture.ManagementClient.GetParametersAsync(), p => p.Name == "myfakefederationupstream1");
     }
@@ -1027,7 +1027,7 @@ public class ManagementClientTests
     {
         var federations = await fixture.ManagementClient.GetFederationsAsync();
 
-        federations.Single().Node.Should().Be($"rabbit@{fixture.Host}");
+        federations.Single().Node.Should().Be($"rabbit@{fixture.Endpoint}");
     }
 
     [Fact]

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
@@ -29,7 +29,7 @@ public class ScenarioTest
         await fixture.ManagementClient.CreatePermissionAsync(vhost, new PermissionInfo(user.Name));
 
         // now log in again as the new user
-        using var management = new ManagementClient(fixture.Host, user.Name, "topSecret");
+        using var management = new ManagementClient(fixture.Endpoint, user.Name, "topSecret");
 
         // test that everything's OK
         await management.IsAliveAsync(vhost);

--- a/Source/EasyNetQ.Management.Client.Tests/ManagementClientConstructorTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/ManagementClientConstructorTests.cs
@@ -10,7 +10,9 @@ public class ManagementClientConstructorTests
     [Fact]
     public void Host_should_not_be_null()
     {
+#pragma warning disable CS0618
         var exception = Assert.Throws<ArgumentException>(() => new ManagementClient(string.Empty, "user", "password"));
+#pragma warning restore CS0618
 
         exception.Message.Should().Be("hostUrl is null or empty");
     }
@@ -18,7 +20,9 @@ public class ManagementClientConstructorTests
     [Fact]
     public void Host_should_have_correct_url_for_ssl()
     {
+#pragma warning disable CS0618
         var exception = Assert.Throws<ArgumentException>(() => new ManagementClient("http://localhost", "user", "password", ssl: true));
+#pragma warning restore CS0618
 
         exception.Message.Should().Be("hostUrl is illegal");
     }
@@ -33,7 +37,9 @@ public class ManagementClientConstructorTests
     [InlineData("[[2001:db8:1111::50]]", false)]
     public void Host_url_should_be_legal(string url, bool isValid)
     {
+#pragma warning disable CS0618
         var exception = Record.Exception(() => new ManagementClient(url, "user", "password"));
+#pragma warning restore CS0618
 
         if (isValid)
         {


### PR DESCRIPTION
Stop using deprecated constructor and ignore tests for it.