### PR TITLE
Rename criterias

### DIFF
--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -652,8 +652,8 @@ public class ManagementClientTests
         var queue = await fixture.ManagementClient.GetQueueAsync(
             Vhost,
             TestQueue,
-            new GetLengthsCriteria(age, increment),
-            new GetRatesCriteria(age, increment)
+            new LengthsCriteria(age, increment),
+            new RatesCriteria(age, increment)
         );
 
         queue.Name.Should().Be(TestQueue);
@@ -670,7 +670,7 @@ public class ManagementClientTests
         await CreateTestQueue(TestQueue);
         await Task.Delay(TimeSpan.FromSeconds(10));
 
-        var queue = await fixture.ManagementClient.GetQueueAsync(Vhost, TestQueue, new GetLengthsCriteria(age, increment));
+        var queue = await fixture.ManagementClient.GetQueueAsync(Vhost, TestQueue, new LengthsCriteria(age, increment));
 
         queue.Name.Should().Be(TestQueue);
         queue.MessagesDetails.Samples.Count.Should().BeGreaterThan(0);
@@ -684,7 +684,7 @@ public class ManagementClientTests
         const int age = 60;
         const int increment = 10;
         await CreateTestQueue(TestQueue);
-        var queue = await fixture.ManagementClient.GetQueueAsync(Vhost, TestQueue, ratesCriteria: new GetRatesCriteria(age, increment));
+        var queue = await fixture.ManagementClient.GetQueueAsync(Vhost, TestQueue, ratesCriteria: new RatesCriteria(age, increment));
         queue.Name.Should().Be(TestQueue);
     }
 
@@ -748,7 +748,7 @@ public class ManagementClientTests
 
         await fixture.ManagementClient.PublishAsync(defaultExchange, publishInfo);
 
-        var messages = await fixture.ManagementClient.GetMessagesFromQueueAsync(queue, new GetMessagesCriteria(1, AckMode.AckRequeueFalse));
+        var messages = await fixture.ManagementClient.GetMessagesFromQueueAsync(queue, new GetMessagesFromQueueInfo(1, AckMode.AckRequeueFalse));
         foreach (var message in messages)
         {
             Console.Out.WriteLine("message.Payload = {0}", message.Payload);

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ScenarioTest.cs
@@ -48,7 +48,7 @@ public class ScenarioTest
         await management.PublishAsync(exchange, new PublishInfo("my_routing_key", "Hello World!"));
 
         // get any messages on the queue
-        var messages = await management.GetMessagesFromQueueAsync(queue, new GetMessagesCriteria(1, AckMode.AckRequeueFalse));
+        var messages = await management.GetMessagesFromQueueAsync(queue, new GetMessagesFromQueueInfo(1, AckMode.AckRequeueFalse));
 
         foreach (var message in messages) Console.Out.WriteLine("message.payload = {0}", message.Payload);
     }

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -17,8 +17,8 @@ public interface IManagementClient : IDisposable
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<Overview> GetOverviewAsync(
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     );
 
@@ -71,7 +71,7 @@ public interface IManagementClient : IDisposable
     /// <param name="cancellationToken"></param>
     Task<Channel> GetChannelAsync(
         string channelName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     );
 
@@ -316,13 +316,13 @@ public interface IManagementClient : IDisposable
     /// </summary>
     /// <param name="vhostName"></param>
     /// <param name="queueName">The queue to retrieve from</param>
-    /// <param name="criteria">The criteria for the retrieve</param>
+    /// <param name="getMessagesFromQueueInfo">The criteria for the retrieve</param>
     /// <param name="cancellationToken"></param>
     /// <returns>Messages</returns>
     Task<IReadOnlyList<Message>> GetMessagesFromQueueAsync(
         string vhostName,
         string queueName,
-        GetMessagesCriteria criteria,
+        GetMessagesFromQueueInfo getMessagesFromQueueInfo,
         CancellationToken cancellationToken = default
     );
 
@@ -552,7 +552,7 @@ public interface IManagementClient : IDisposable
     Task<Exchange> GetExchangeAsync(
         string vhostName,
         string exchangeName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     );
 
@@ -568,8 +568,8 @@ public interface IManagementClient : IDisposable
     Task<Queue> GetQueueAsync(
         string vhostName,
         string queueName,
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     );
 

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -125,8 +125,8 @@ public class ManagementClient : IManagementClient
     public Uri Endpoint => httpClient.BaseAddress!;
 
     public Task<Overview> GetOverviewAsync(
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -168,7 +168,7 @@ public class ManagementClient : IManagementClient
 
     public Task<Channel> GetChannelAsync(
         string channelName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -202,7 +202,7 @@ public class ManagementClient : IManagementClient
     public Task<Exchange> GetExchangeAsync(
         string vhostName,
         string exchangeName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -216,8 +216,8 @@ public class ManagementClient : IManagementClient
     public Task<Queue> GetQueueAsync(
         string vhostName,
         string queueName,
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -350,13 +350,13 @@ public class ManagementClient : IManagementClient
     public Task<IReadOnlyList<Message>> GetMessagesFromQueueAsync(
         string vhostName,
         string queueName,
-        GetMessagesCriteria criteria,
+        GetMessagesFromQueueInfo getMessagesFromQueueInfo,
         CancellationToken cancellationToken = default
     )
     {
-        return PostAsync<GetMessagesCriteria, IReadOnlyList<Message>>(
+        return PostAsync<GetMessagesFromQueueInfo, IReadOnlyList<Message>>(
             Queues / vhostName / queueName / "get",
-            criteria,
+            getMessagesFromQueueInfo,
             cancellationToken
         );
     }

--- a/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
@@ -14,8 +14,8 @@ public static class ManagementClientExtensions
     /// <returns></returns>
     public static Overview GetOverview(
         this IManagementClient client,
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -114,7 +114,7 @@ public static class ManagementClientExtensions
     public static Channel GetChannel(
         this IManagementClient client,
         string channelName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -659,15 +659,15 @@ public static class ManagementClientExtensions
     /// </summary>
     /// <param name="client"></param>
     /// <param name="queue">The queue to retrieve from</param>
-    /// <param name="criteria">The criteria for the retrieve</param>
+    /// <param name="getMessagesFromQueueInfo">The criteria for the retrieve</param>
     /// <param name="cancellationToken"></param>
     /// <returns>Messages</returns>
     public static Task<IReadOnlyList<Message>> GetMessagesFromQueueAsync(
         this IManagementClient client,
         Queue queue,
-        GetMessagesCriteria criteria,
+        GetMessagesFromQueueInfo getMessagesFromQueueInfo,
         CancellationToken cancellationToken = default
-    ) => client.GetMessagesFromQueueAsync(queue.Vhost, queue.Name, criteria, cancellationToken);
+    ) => client.GetMessagesFromQueueAsync(queue.Vhost, queue.Name, getMessagesFromQueueInfo, cancellationToken);
 
     /// <summary>
     ///     Get messages from a queue.
@@ -678,17 +678,17 @@ public static class ManagementClientExtensions
     /// </summary>
     /// <param name="client"></param>
     /// <param name="queue">The queue to retrieve from</param>
-    /// <param name="criteria">The criteria for the retrieve</param>
+    /// <param name="getMessagesFromQueueInfo">The criteria for the retrieve</param>
     /// <param name="cancellationToken"></param>
     /// <returns>Messages</returns>
     public static IReadOnlyList<Message> GetMessagesFromQueue(
         this IManagementClient client,
         Queue queue,
-        GetMessagesCriteria criteria,
+        GetMessagesFromQueueInfo getMessagesFromQueueInfo,
         CancellationToken cancellationToken = default
     )
     {
-        return client.GetMessagesFromQueueAsync(queue, criteria, cancellationToken)
+        return client.GetMessagesFromQueueAsync(queue, getMessagesFromQueueInfo, cancellationToken)
             .GetAwaiter()
             .GetResult();
     }
@@ -1168,7 +1168,6 @@ public static class ManagementClientExtensions
             .GetResult();
     }
 
-
     /// <summary>
     ///     Declares a test queue, then publishes and consumes a message. Intended for use
     ///     by monitoring tools. If everything is working correctly, will return true.
@@ -1183,7 +1182,6 @@ public static class ManagementClientExtensions
         Vhost vhost,
         CancellationToken cancellationToken = default
     ) => client.IsAliveAsync(vhost.Name, cancellationToken);
-
 
     /// <summary>
     ///     Declares a test queue, then publishes and consumes a message. Intended for use
@@ -1218,7 +1216,7 @@ public static class ManagementClientExtensions
         this IManagementClient client,
         Vhost vhost,
         string exchangeName,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     ) => client.GetExchangeAsync(vhost.Name, exchangeName, ratesCriteria, cancellationToken);
 
@@ -1235,7 +1233,7 @@ public static class ManagementClientExtensions
         this IManagementClient client,
         string exchangeName,
         Vhost vhost,
-        GetRatesCriteria? ratesCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -1258,8 +1256,8 @@ public static class ManagementClientExtensions
         this IManagementClient client,
         Vhost vhost,
         string queueName,
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     ) => client.GetQueueAsync(vhost.Name, queueName, lengthsCriteria, ratesCriteria, cancellationToken);
 
@@ -1277,8 +1275,8 @@ public static class ManagementClientExtensions
         this IManagementClient client,
         Vhost vhost,
         string queueName,
-        GetLengthsCriteria? lengthsCriteria = null,
-        GetRatesCriteria? ratesCriteria = null,
+        LengthsCriteria? lengthsCriteria = null,
+        RatesCriteria? ratesCriteria = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -1513,7 +1511,6 @@ public static class ManagementClientExtensions
 
         await client.CreateUserAsync(userInfo, cancellationToken).ConfigureAwait(false);
     }
-
 
     /// <summary>
     ///     Returns true if there are any alarms in effect in the cluster

--- a/Source/EasyNetQ.Management.Client/Model/GetMessagesFromQueueInfo.cs
+++ b/Source/EasyNetQ.Management.Client/Model/GetMessagesFromQueueInfo.cs
@@ -1,12 +1,10 @@
 ﻿namespace EasyNetQ.Management.Client.Model;
 
-#nullable disable
-
-public class GetMessagesCriteria
+public class GetMessagesFromQueueInfo
 {
-    public long Count { get; private set; }
-    public AckMode Ackmode { get; private set; }
-    public string Encoding { get; private set; }
+    public long Count { get; }
+    public AckMode Ackmode { get; }
+    public string Encoding { get; }
 
     /// <summary>
     /// Constructor
@@ -17,7 +15,7 @@ public class GetMessagesCriteria
     /// <param name="ackMode">
     /// Determines if the message(s) should be placed back into the queue.
     /// </param>
-    public GetMessagesCriteria(long count, AckMode ackMode)
+    public GetMessagesFromQueueInfo(long count, AckMode ackMode)
     {
         Ackmode = ackMode;
         Count = count;

--- a/Source/EasyNetQ.Management.Client/Model/LengthsCriteria.cs
+++ b/Source/EasyNetQ.Management.Client/Model/LengthsCriteria.cs
@@ -1,20 +1,20 @@
 ﻿namespace EasyNetQ.Management.Client.Model;
 
-public class GetLengthsCriteria
+public class LengthsCriteria
 {
     /// <summary>
     /// Create a new object for specifying queue length age and increment
     /// </summary>
     /// <param name="age">Age (in seconds) of oldest sample to return</param>
     /// <param name="increment">Interval (in seconds) between samples</param>
-    public GetLengthsCriteria(int age, int increment)
+    public LengthsCriteria(int age, int increment)
     {
         LengthsAge = age;
         LengthsIncr = increment;
     }
 
-    public int LengthsAge { get; private set; }
-    public int LengthsIncr { get; private set; }
+    public int LengthsAge { get; }
+    public int LengthsIncr { get; }
 
     public IReadOnlyDictionary<string, string> ToQueryParameters()
     {

--- a/Source/EasyNetQ.Management.Client/Model/RatesCriteria.cs
+++ b/Source/EasyNetQ.Management.Client/Model/RatesCriteria.cs
@@ -1,20 +1,20 @@
 ﻿namespace EasyNetQ.Management.Client.Model;
 
-public class GetRatesCriteria
+public class RatesCriteria
 {
     /// <summary>
     /// Create a new object for specifying rate age and increment
     /// </summary>
     /// <param name="age">Age (in seconds) of oldest sample to return</param>
     /// <param name="increment">Interval (in seconds) between samples</param>
-    public GetRatesCriteria(int age, int increment)
+    public RatesCriteria(int age, int increment)
     {
         MsgRatesAge = age;
         MsgRatesIncr = increment;
     }
 
-    public int MsgRatesAge { get; private set; }
-    public int MsgRatesIncr { get; private set; }
+    public int MsgRatesAge { get; }
+    public int MsgRatesIncr { get; }
 
     public IReadOnlyDictionary<string, string> ToQueryParameters()
     {


### PR DESCRIPTION
Remove `Get` prefix from `GetLengthsCriteria`/`GetRatesCriteria`. 

`GetMessagesCriteria` renamed to `GetMessagesFromQueueInfo`.