### PR TITLE
Implemented CreateFederationUpstream method

### DIFF
--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -154,6 +154,8 @@ namespace EasyNetQ.Management.Client
         public static System.Threading.Tasks.Task CreateExchangeAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.ExchangeInfo exchangeInfo, EasyNetQ.Management.Client.Model.Vhost vhost, System.Threading.CancellationToken cancellationToken = default) { }
         public static void CreateExchangeBinding(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange sourceExchange, EasyNetQ.Management.Client.Model.Exchange destinationExchange, EasyNetQ.Management.Client.Model.BindingInfo bindingInfo, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task CreateExchangeBindingAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange sourceExchange, EasyNetQ.Management.Client.Model.Exchange destinationExchange, EasyNetQ.Management.Client.Model.BindingInfo bindingInfo, System.Threading.CancellationToken cancellationToken = default) { }
+        public static void CreateFederationUpstream(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string federationUpstreamName, EasyNetQ.Management.Client.Model.ParameterFederationValue federationUpstreamDescription, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Threading.Tasks.Task CreateFederationUpstreamAsync(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string federationUpstreamName, EasyNetQ.Management.Client.Model.ParameterFederationValue federationUpstreamDescription, System.Threading.CancellationToken cancellationToken = default) { }
         public static void CreateParameter(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Parameter parameter, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task CreateParameterAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Parameter parameter, System.Threading.CancellationToken cancellationToken = default) { }
         public static void CreatePermission(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, EasyNetQ.Management.Client.Model.PermissionInfo permissionInfo, System.Threading.CancellationToken cancellationToken = default) { }
@@ -267,6 +269,17 @@ namespace EasyNetQ.Management.Client.Model
     {
         public const string AMQP091 = "amqp091";
         public const string AMQP10 = "amqp10";
+    }
+    public class AmqpUri
+    {
+        public AmqpUri(string hostName) { }
+        public AmqpUri(string hostName, int? port) { }
+        public AmqpUri(string hostName, int? port, string? username, string? password) { }
+        public string HostName { get; set; }
+        public string? Password { get; set; }
+        public int? Port { get; set; }
+        public string? Username { get; set; }
+        public override string ToString() { }
     }
     public class Application : System.IEquatable<EasyNetQ.Management.Client.Model.Application>
     {
@@ -829,6 +842,13 @@ namespace EasyNetQ.Management.Client.Model
         public string Name { get; set; }
         public object Value { get; set; }
         public string Vhost { get; set; }
+    }
+    public class ParameterFederationValue : System.IEquatable<EasyNetQ.Management.Client.Model.ParameterFederationValue>
+    {
+        public ParameterFederationValue(EasyNetQ.Management.Client.Model.AmqpUri Uri, int Expires) { }
+        public int Expires { get; set; }
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.ObjectToStringConverter<EasyNetQ.Management.Client.Model.AmqpUri>))]
+        public EasyNetQ.Management.Client.Model.AmqpUri Uri { get; set; }
     }
     public class ParameterShovelValue : System.IEquatable<EasyNetQ.Management.Client.Model.ParameterShovelValue>
     {

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -475,6 +475,19 @@ public class ManagementClientTests
     }
 
     [Fact]
+    public async Task Should_be_able_to_create_federation_upstream_parameter_with_extension_method()
+    {
+        var amqpUri = new AmqpUri(fixture.Endpoint.Host, fixture.Endpoint.Port, fixture.User, fixture.Password);
+
+        await fixture.ManagementClient.CreateFederationUpstreamAsync(
+            vhostName: Vhost.Name,
+            federationUpstreamName: "myfakefederationupstream-extension",
+            federationUpstreamDescription: new ParameterFederationValue(amqpUri, Expires: 3600000)
+        );
+        Assert.Contains(await fixture.ManagementClient.GetParametersAsync(), p => p.Name == "myfakefederationupstream-extension");
+    }
+
+    [Fact]
     public async Task Should_be_able_to_create_permissions()
     {
         var user = (await fixture.ManagementClient.GetUsersAsync()).SingleOrDefault(x => x.Name == TestUser);

--- a/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
@@ -1629,4 +1629,41 @@ public static class ManagementClientExtensions
             .GetAwaiter()
             .GetResult();
     }
+
+    /// <summary>
+    ///     Creates a federation upstream in a specific vhost
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="vhostName"></param>
+    /// <param name="federationUpstreamName"></param>
+    /// <param name="federationUpstreamDescription"></param>
+    /// <param name="cancellationToken"></param>
+    public static Task CreateFederationUpstreamAsync(
+        this IManagementClient client,
+        string vhostName,
+        string federationUpstreamName,
+        ParameterFederationValue federationUpstreamDescription,
+        CancellationToken cancellationToken = default
+    ) => client.CreateParameterAsync("federation-upstream", vhostName, federationUpstreamName, federationUpstreamDescription, cancellationToken);
+
+    /// <summary>
+    ///     Creates a federation upstream in a specific vhost
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="vhostName"></param>
+    /// <param name="federationUpstreamName"></param>
+    /// <param name="federationUpstreamDescription"></param>
+    /// <param name="cancellationToken"></param>
+    public static void CreateFederationUpstream(
+        this IManagementClient client,
+        string vhostName,
+        string federationUpstreamName,
+        ParameterFederationValue federationUpstreamDescription,
+        CancellationToken cancellationToken = default
+    )
+    {
+        client.CreateParameterAsync("federation-upstream", vhostName, federationUpstreamName, federationUpstreamDescription, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
 }

--- a/Source/EasyNetQ.Management.Client/Model/AmqpUri.cs
+++ b/Source/EasyNetQ.Management.Client/Model/AmqpUri.cs
@@ -1,0 +1,43 @@
+﻿namespace EasyNetQ.Management.Client.Model
+{
+    public class AmqpUri
+    {
+        public string HostName { get; set; }
+        public int? Port { get; set; }
+        public string? Username { get; set; }
+        public string? Password { get; set; }
+
+        public AmqpUri(string hostName)
+        {
+            HostName = hostName;
+        }
+
+        public AmqpUri(string hostName, int? port) : this(hostName)
+        {
+            Port = port;
+        }
+
+        public AmqpUri(string hostName, int? port, string? username, string? password) : this(hostName, port)
+        {
+            Username = username;
+            Password = password;
+        }
+
+        public override string ToString()
+        {
+            var userInfo = "";
+            if (string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(Password))
+            {
+                userInfo = $"{Username}:{Password}@";
+            }
+
+            var portInfo = "";
+            if (Port.GetValueOrDefault(0) > 0)
+            {
+                portInfo = $":{Port}";
+            }
+
+            return $"amqp://{userInfo}{HostName}{portInfo}";
+        }
+    }
+}

--- a/Source/EasyNetQ.Management.Client/Model/ParameterFederationValue.cs
+++ b/Source/EasyNetQ.Management.Client/Model/ParameterFederationValue.cs
@@ -1,0 +1,10 @@
+using EasyNetQ.Management.Client.Serialization;
+using System.Text.Json.Serialization;
+
+namespace EasyNetQ.Management.Client.Model;
+
+public record ParameterFederationValue(
+    [property: JsonConverter(typeof(ObjectToStringConverter<AmqpUri>))]
+    AmqpUri Uri,
+    int Expires
+);

--- a/Source/EasyNetQ.Management.Client/Serialization/ObjectToStringConverter.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/ObjectToStringConverter.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EasyNetQ.Management.Client.Serialization;
+
+internal sealed class ObjectToStringConverter<T> : JsonConverter<T>
+{
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value?.ToString());
+    }
+
+    public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
### Reason
Having a convenient method to simplify the creation of a `federation-upstream`

### Remarks
* `AmqpUri` class was introduced to have a convenience object to construct an amqp connection string
* `ObjectToStringConverter.cs` has been implemented to serialize a complex object using its `ToString` method: in this context, it serves to correctly compose the `uri` property for the federation contract
* `ParameterFederationValue` serves as value object to federation API request (source: [RabbitMQ Federation](https://www.rabbitmq.com/federation.html))
* The methods has been written as extensions, as we saw in PR #224 context