### PR TITLE
Update depenency

### DIFF
--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -45,6 +45,11 @@
     <None Include="..\..\license.txt" Pack="true" PackagePath="" />
     <None Include="..\..\Assets\EasyNetQ.png" Pack="true" PackagePath="" />
   </ItemGroup>
+   
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="6.0.0" />
+    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
@@ -57,7 +62,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="6.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Reference `System.Text.Json`/`System.Net.Http.Json` only for netstandard2.0 since it had been included in the framework for .NET 6 and above