### PR TITLE
Add  PolicyDefinition.ExtensionData, Queue.ExtensionData, IMC.GetQueuesWithoutStatsAsync

### DIFF
--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -59,6 +59,7 @@ namespace EasyNetQ.Management.Client
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue>> GetQueuesAsync(string vhostName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue>> GetQueuesByPageAsync(EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue>> GetQueuesByPageAsync(string vhostName, EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.QueueWithoutStats>> GetQueuesWithoutStatsAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.TopicPermission>> GetTopicPermissionsAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.User> GetUserAsync(string userName, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.User>> GetUsersAsync(System.Threading.CancellationToken cancellationToken = default);
@@ -137,6 +138,7 @@ namespace EasyNetQ.Management.Client
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue>> GetQueuesAsync(string vhostName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue>> GetQueuesByPageAsync(EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue>> GetQueuesByPageAsync(string vhostName, EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.QueueWithoutStats>> GetQueuesWithoutStatsAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.TopicPermission>> GetTopicPermissionsAsync(System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.User> GetUserAsync(string userName, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.User>> GetUsersAsync(System.Threading.CancellationToken cancellationToken = default) { }
@@ -209,14 +211,18 @@ namespace EasyNetQ.Management.Client
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Binding>> GetBindingsWithSourceAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange exchange, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.Channel GetChannel(this EasyNetQ.Management.Client.IManagementClient client, string channelName, EasyNetQ.Management.Client.Model.RatesCriteria? ratesCriteria = null, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Channel> GetChannels(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Channel> GetChannels(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Connection connection, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Channel> GetChannels(this EasyNetQ.Management.Client.IManagementClient client, string connectionName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Channel>> GetChannelsAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Connection connection, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Connection> GetConnections(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Connection> GetConnections(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.Definitions GetDefinitions(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.Exchange GetExchange(this EasyNetQ.Management.Client.IManagementClient client, string exchangeName, EasyNetQ.Management.Client.Model.Vhost vhost, EasyNetQ.Management.Client.Model.RatesCriteria? ratesCriteria = null, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.Exchange> GetExchangeAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, string exchangeName, EasyNetQ.Management.Client.Model.RatesCriteria? ratesCriteria = null, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Binding> GetExchangeBindings(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange fromExchange, EasyNetQ.Management.Client.Model.Exchange toExchange, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Binding>> GetExchangeBindingsAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange fromExchange, EasyNetQ.Management.Client.Model.Exchange toExchange, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Exchange> GetExchanges(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Exchange> GetExchanges(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.Parameter GetFederationUpstream(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string federationUpstreamName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.Parameter> GetFederationUpstreamAsync(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string federationUpstreamName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Federation> GetFederations(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
@@ -233,10 +239,12 @@ namespace EasyNetQ.Management.Client
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Binding>> GetQueueBindingsAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Exchange exchange, EasyNetQ.Management.Client.Model.Queue queue, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue> GetQueues(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue> GetQueues(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue> GetQueues(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Queue>> GetQueuesAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue> GetQueuesByPage(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue> GetQueuesByPage(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.PageResult<EasyNetQ.Management.Client.Model.Queue>> GetQueuesByPageAsync(this EasyNetQ.Management.Client.IManagementClient client, EasyNetQ.Management.Client.Model.Vhost vhost, EasyNetQ.Management.Client.Model.PageCriteria pageCriteria, System.Threading.CancellationToken cancellationToken = default) { }
+        public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.QueueWithoutStats> GetQueuesWithoutStats(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
         public static EasyNetQ.Management.Client.Model.Parameter GetShovel(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string shovelName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Threading.Tasks.Task<EasyNetQ.Management.Client.Model.Parameter> GetShovelAsync(this EasyNetQ.Management.Client.IManagementClient client, string vhostName, string shovelName, System.Threading.CancellationToken cancellationToken = default) { }
         public static System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.TopicPermission> GetTopicPermissions(this EasyNetQ.Management.Client.IManagementClient client, System.Threading.CancellationToken cancellationToken = default) { }
@@ -431,7 +439,7 @@ namespace EasyNetQ.Management.Client.Model
                     long SendOct,
                     long SendCnt,
                     long SendPend,
-                    string State,
+                    string? State,
                     string? LastBlockedBy,
                     string? LastBlockedAge,
                     long Channels,
@@ -440,13 +448,13 @@ namespace EasyNetQ.Management.Client.Model
                     string Name,
                     string? Address,
                     int Port,
-                    string PeerHost,
+                    string? PeerHost,
                     int PeerPort,
                     bool Ssl,
                     string? PeerCertSubject,
                     string? PeerCertIssuer,
                     string? PeerCertValidity,
-                    string AuthMechanism,
+                    string? AuthMechanism,
                     string? SslProtocol,
                     string? SslKeyExchange,
                     string? SslCipher,
@@ -458,7 +466,7 @@ namespace EasyNetQ.Management.Client.Model
                     long FrameMax,
                     System.Collections.Generic.IReadOnlyDictionary<string, object?> ClientProperties) { }
         public string? Address { get; init; }
-        public string AuthMechanism { get; init; }
+        public string? AuthMechanism { get; init; }
         public long Channels { get; init; }
         [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter?))]
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> ClientProperties { get; init; }
@@ -470,7 +478,7 @@ namespace EasyNetQ.Management.Client.Model
         public string? PeerCertIssuer { get; init; }
         public string? PeerCertSubject { get; init; }
         public string? PeerCertValidity { get; init; }
-        public string PeerHost { get; init; }
+        public string? PeerHost { get; init; }
         public int PeerPort { get; init; }
         public int Port { get; init; }
         public string Protocol { get; init; }
@@ -484,7 +492,7 @@ namespace EasyNetQ.Management.Client.Model
         public string? SslKeyExchange { get; init; }
         public string? SslProtocol { get; init; }
         public bool Ssl { get; init; }
-        public string State { get; init; }
+        public string? State { get; init; }
         public long Timeout { get; init; }
         public string Type { get; init; }
         public string User { get; init; }
@@ -980,6 +988,8 @@ namespace EasyNetQ.Management.Client.Model
                     string? FederationUpstream = null,
                     string? FederationUpstreamSet = null,
                     string? QueueMode = null) { }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, object>? ExtensionData { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("alternate-exchange")]
         public string? AlternateExchange { get; init; }
         [System.Text.Json.Serialization.JsonPropertyName("consumer-timeout")]
@@ -1062,60 +1072,55 @@ namespace EasyNetQ.Management.Client.Model
         public PublishResult(bool Routed) { }
         public bool Routed { get; init; }
     }
-    public class Queue : System.IEquatable<EasyNetQ.Management.Client.Model.Queue>
+    public class Queue : EasyNetQ.Management.Client.Model.QueueWithoutStats, System.IEquatable<EasyNetQ.Management.Client.Model.Queue>
     {
         public Queue(
+                    string Name,
+                    string Vhost,
+                    EasyNetQ.Management.Client.Model.QueueType Type,
+                    string Node,
+                    string? State,
+                    System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments,
+                    bool Durable,
+                    bool Exclusive,
+                    bool AutoDelete,
+                    long MessagesReady,
+                    long MessagesUnacknowledged,
+                    long Messages,
                     long Memory,
                     string? IdleSince,
                     string? Policy,
                     string? ExclusiveConsumerTag,
-                    long MessagesReady,
-                    long MessagesUnacknowledged,
-                    long Messages,
+                    long MessageBytes,
                     long Consumers,
                     long ActiveConsumers,
                     EasyNetQ.Management.Client.Model.BackingQueueStatus? BackingQueueStatus,
                     System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.ConsumerDetail>? ConsumerDetails,
                     long? HeadMessageTimestamp,
-                    string Name,
-                    string Vhost,
-                    bool Durable,
-                    bool Exclusive,
-                    bool AutoDelete,
-                    System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments,
-                    string? Node,
                     System.Collections.Generic.IReadOnlyList<string>? SlaveNodes,
                     System.Collections.Generic.IReadOnlyList<string>? SynchronisedSlaveNodes,
                     EasyNetQ.Management.Client.Model.LengthsDetails? MessagesDetails,
                     EasyNetQ.Management.Client.Model.LengthsDetails? MessagesReadyDetails,
                     EasyNetQ.Management.Client.Model.LengthsDetails? MessagesUnacknowledgedDetails,
                     EasyNetQ.Management.Client.Model.MessageStats? MessageStats) { }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.Dictionary<string, object>? ExtensionData { get; set; }
         public long ActiveConsumers { get; init; }
-        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter?))]
-        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments { get; init; }
-        public bool AutoDelete { get; init; }
         public EasyNetQ.Management.Client.Model.BackingQueueStatus? BackingQueueStatus { get; init; }
         public System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.ConsumerDetail>? ConsumerDetails { get; init; }
         public long Consumers { get; init; }
-        public bool Durable { get; init; }
         public string? ExclusiveConsumerTag { get; init; }
-        public bool Exclusive { get; init; }
         public long? HeadMessageTimestamp { get; init; }
         public string? IdleSince { get; init; }
         public long Memory { get; init; }
+        public long MessageBytes { get; init; }
         public EasyNetQ.Management.Client.Model.MessageStats? MessageStats { get; init; }
         public EasyNetQ.Management.Client.Model.LengthsDetails? MessagesDetails { get; init; }
         public EasyNetQ.Management.Client.Model.LengthsDetails? MessagesReadyDetails { get; init; }
-        public long MessagesReady { get; init; }
         public EasyNetQ.Management.Client.Model.LengthsDetails? MessagesUnacknowledgedDetails { get; init; }
-        public long MessagesUnacknowledged { get; init; }
-        public long Messages { get; init; }
-        public string Name { get; init; }
-        public string? Node { get; init; }
         public string? Policy { get; init; }
         public System.Collections.Generic.IReadOnlyList<string>? SlaveNodes { get; init; }
         public System.Collections.Generic.IReadOnlyList<string>? SynchronisedSlaveNodes { get; init; }
-        public string Vhost { get; init; }
     }
     public class QueueInfo : System.IEquatable<EasyNetQ.Management.Client.Model.QueueInfo>
     {
@@ -1149,10 +1154,31 @@ namespace EasyNetQ.Management.Client.Model
         public long MessagesUnacknowledged { get; init; }
         public long Messages { get; init; }
     }
+    public enum QueueType
+    {
+        Classic = 0,
+        Quorum = 1,
+        Stream = 2,
+    }
     public enum QueueVersion
     {
         V1 = 1,
         V2 = 2,
+    }
+    public class QueueWithoutStats : EasyNetQ.Management.Client.Model.QueueName, System.IEquatable<EasyNetQ.Management.Client.Model.QueueWithoutStats>
+    {
+        public QueueWithoutStats(string Name, string Vhost, EasyNetQ.Management.Client.Model.QueueType Type, string Node, string? State, System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments, bool Durable, bool Exclusive, bool AutoDelete, long MessagesReady, long MessagesUnacknowledged, long Messages) { }
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter))]
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments { get; init; }
+        public bool AutoDelete { get; init; }
+        public bool Durable { get; init; }
+        public bool Exclusive { get; init; }
+        public long MessagesReady { get; init; }
+        public long MessagesUnacknowledged { get; init; }
+        public long Messages { get; init; }
+        public string Node { get; init; }
+        public string? State { get; init; }
+        public EasyNetQ.Management.Client.Model.QueueType Type { get; init; }
     }
     public class RatesCriteria : System.IEquatable<EasyNetQ.Management.Client.Model.RatesCriteria>
     {

--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -1168,7 +1168,7 @@ namespace EasyNetQ.Management.Client.Model
     public class QueueWithoutStats : EasyNetQ.Management.Client.Model.QueueName, System.IEquatable<EasyNetQ.Management.Client.Model.QueueWithoutStats>
     {
         public QueueWithoutStats(string Name, string Vhost, EasyNetQ.Management.Client.Model.QueueType Type, string? Node, string? State, System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments, bool Durable, bool Exclusive, bool AutoDelete, long MessagesReady, long MessagesUnacknowledged, long Messages) { }
-        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter?))]
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments { get; init; }
         public bool AutoDelete { get; init; }
         public bool Durable { get; init; }

--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -1078,7 +1078,7 @@ namespace EasyNetQ.Management.Client.Model
                     string Name,
                     string Vhost,
                     EasyNetQ.Management.Client.Model.QueueType Type,
-                    string Node,
+                    string? Node,
                     string? State,
                     System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments,
                     bool Durable,
@@ -1167,7 +1167,7 @@ namespace EasyNetQ.Management.Client.Model
     }
     public class QueueWithoutStats : EasyNetQ.Management.Client.Model.QueueName, System.IEquatable<EasyNetQ.Management.Client.Model.QueueWithoutStats>
     {
-        public QueueWithoutStats(string Name, string Vhost, EasyNetQ.Management.Client.Model.QueueType Type, string Node, string? State, System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments, bool Durable, bool Exclusive, bool AutoDelete, long MessagesReady, long MessagesUnacknowledged, long Messages) { }
+        public QueueWithoutStats(string Name, string Vhost, EasyNetQ.Management.Client.Model.QueueType Type, string? Node, string? State, System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments, bool Durable, bool Exclusive, bool AutoDelete, long MessagesReady, long MessagesUnacknowledged, long Messages) { }
         [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.StringObjectReadOnlyDictionaryConverter))]
         public System.Collections.Generic.IReadOnlyDictionary<string, object?> Arguments { get; init; }
         public bool AutoDelete { get; init; }
@@ -1176,7 +1176,7 @@ namespace EasyNetQ.Management.Client.Model
         public long MessagesReady { get; init; }
         public long MessagesUnacknowledged { get; init; }
         public long Messages { get; init; }
-        public string Node { get; init; }
+        public string? Node { get; init; }
         public string? State { get; init; }
         public EasyNetQ.Management.Client.Model.QueueType Type { get; init; }
     }

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1230,7 +1230,7 @@ public class ManagementClientTests
     {
         await CreateTestQueue(TestQueue);
         var queues = await fixture.ManagementClient.GetQueuesWithoutStatsAsync();
-        queues.Count.Should().BeGreaterThan(0);
+        queues.Should().NotBeNullOrEmpty();
     }
 
 

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -266,7 +266,8 @@ public class ManagementClientTests
                     MaxLengthBytes: maxLengthBytes,
                     Overflow: overflow,
                     ConsumerTimeout: consumerTimeout
-                ) { ExtensionData = extensionData },
+                )
+                { ExtensionData = extensionData },
                 Priority: priority
             )
         );

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/ManagementClientTests.cs
@@ -1219,10 +1219,6 @@ public class ManagementClientTests
                 queues[0].ExtensionData.Should().NotBeNullOrEmpty();
                 break;
             }
-            else
-            {
-                queues[0].ExtensionData.Should().BeNull();
-            }
         }
     }
 

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -123,19 +123,19 @@ public interface IManagementClient : IDisposable
     Task<IReadOnlyList<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     A list of all queues.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     ///     A list of queues for a page.
     /// </summary>
     /// <param name="pageCriteria"></param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<PageResult<Queue>> GetQueuesByPageAsync(PageCriteria pageCriteria, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     A list of all queues.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     A list of all queues for a virtual host.

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -99,7 +99,7 @@ public interface IManagementClient : IDisposable
     Task<PageResult<Exchange>> GetExchangesByPageAsync(PageCriteria pageCriteria, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     A list of all exchanges.
+    ///     A list of all exchanges for a virtual host.
     /// </summary>
     /// <param name="vhostName"></param>
     /// <param name="cancellationToken"></param>
@@ -131,13 +131,6 @@ public interface IManagementClient : IDisposable
     Task<PageResult<Queue>> GetQueuesByPageAsync(PageCriteria pageCriteria, CancellationToken cancellationToken = default);
 
     /// <summary>
-    ///     A list of all queues.
-    /// </summary>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
-    Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     ///     A list of all queues for a virtual host.
     /// </summary>
     /// <param name="vhostName"></param>
@@ -153,6 +146,13 @@ public interface IManagementClient : IDisposable
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     Task<PageResult<Queue>> GetQueuesByPageAsync(string vhostName, PageCriteria pageCriteria, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     A list of all queues.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     A list of all bindings.

--- a/Source/EasyNetQ.Management.Client/IManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/IManagementClient.cs
@@ -123,6 +123,13 @@ public interface IManagementClient : IDisposable
     Task<IReadOnlyList<Queue>> GetQueuesAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    ///     A list of all queues.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     A list of queues for a page.
     /// </summary>
     /// <param name="pageCriteria"></param>

--- a/Source/EasyNetQ.Management.Client/ManagementClient.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClient.cs
@@ -42,6 +42,11 @@ public class ManagementClient : IManagementClient
     private static readonly RelativePath Health = Api / "health";
     private static readonly RelativePath Rebalance = Api / "rebalance";
 
+    private static readonly Dictionary<string, string> GetQueuesWithoutStatsQueryParameters = new Dictionary<string, string> {
+        { "disable_stats", "true" },
+        { "enable_queue_totals", "true" }
+    };
+
     internal static readonly JsonSerializerOptions SerializerOptions;
 
     private readonly HttpClient httpClient;
@@ -311,6 +316,11 @@ public class ManagementClient : IManagementClient
     public Task<PageResult<Queue>> GetQueuesByPageAsync(string vhostName, PageCriteria pageCriteria, CancellationToken cancellationToken = default)
     {
         return GetAsync<PageResult<Queue>>(Queues / vhostName, pageCriteria.ToQueryParameters(), cancellationToken);
+    }
+
+    public Task<IReadOnlyList<QueueWithoutStats>> GetQueuesWithoutStatsAsync(CancellationToken cancellationToken = default)
+    {
+        return GetAsync<IReadOnlyList<QueueWithoutStats>>(Queues, GetQueuesWithoutStatsQueryParameters, cancellationToken);
     }
 
     public Task CreateQueueAsync(

--- a/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
@@ -201,7 +201,7 @@ public static class ManagementClientExtensions
     /// <returns></returns>
     public static IReadOnlyList<Exchange> GetExchanges(
         this IManagementClient client,
-        string vhostName, 
+        string vhostName,
         CancellationToken cancellationToken = default
     )
     {

--- a/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/ManagementClientExtensions.cs
@@ -24,7 +24,6 @@ public static class ManagementClientExtensions
             .GetResult();
     }
 
-
     /// <summary>
     ///     A list of nodes in the RabbitMQ cluster.
     /// </summary>
@@ -75,6 +74,24 @@ public static class ManagementClientExtensions
     }
 
     /// <summary>
+    ///     A list of all open connections on the specified VHost.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="vhostName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<Connection> GetConnections(
+        this IManagementClient client,
+        string vhostName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return client.GetConnectionsAsync(vhostName, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
     ///     A list of all open channels.
     /// </summary>
     /// <param name="client"></param>
@@ -91,7 +108,25 @@ public static class ManagementClientExtensions
     }
 
     /// <summary>
-    ///     A list of all open channels.
+    ///     A list of all open channels for the given connection.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="connectionName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<Channel> GetChannels(
+        this IManagementClient client,
+        string connectionName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return client.GetChannelsAsync(connectionName, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    ///     A list of all open channels for the given connection.
     /// </summary>
     /// <param name="client"></param>
     /// <param name="connection"></param>
@@ -102,6 +137,24 @@ public static class ManagementClientExtensions
         Connection connection,
         CancellationToken cancellationToken = default
     ) => client.GetChannelsAsync(connection.Name, cancellationToken);
+
+    /// <summary>
+    ///     A list of all open channels for the given connection.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="connection"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<Channel> GetChannels(
+        this IManagementClient client,
+        Connection connection,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return client.GetChannelsAsync(connection, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
 
     /// <summary>
     ///     Gets the channel. This returns more detail, including consumers than the GetChannels method.
@@ -140,6 +193,24 @@ public static class ManagementClientExtensions
     }
 
     /// <summary>
+    ///     A list of all exchanges for a virtual host.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="vhostName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<Exchange> GetExchanges(
+        this IManagementClient client,
+        string vhostName, 
+        CancellationToken cancellationToken = default
+    )
+    {
+        return client.GetExchangesAsync(vhostName, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
     ///     A list of all queues.
     /// </summary>
     /// <param name="client"></param>
@@ -151,6 +222,24 @@ public static class ManagementClientExtensions
     )
     {
         return client.GetQueuesAsync(cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+    }
+
+    /// <summary>
+    ///     A list of all queues for a virtual host.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="vhostName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<Queue> GetQueues(
+        this IManagementClient client,
+        string vhostName,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return client.GetQueuesAsync(vhostName, cancellationToken)
             .GetAwaiter()
             .GetResult();
     }
@@ -238,6 +327,17 @@ public static class ManagementClientExtensions
             .GetAwaiter()
             .GetResult();
     }
+
+    /// <summary>
+    ///     A list of all queues without stats.
+    /// </summary>
+    /// <param name="client"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public static IReadOnlyList<QueueWithoutStats> GetQueuesWithoutStats(
+        this IManagementClient client,
+        CancellationToken cancellationToken = default
+    ) => client.GetQueuesWithoutStatsAsync(cancellationToken).GetAwaiter().GetResult();
 
     /// <summary>
     ///     A list of all bindings.

--- a/Source/EasyNetQ.Management.Client/Model/Connection.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Connection.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 using EasyNetQ.Management.Client.Serialization;
 
 namespace EasyNetQ.Management.Client.Model;
@@ -9,7 +9,7 @@ public record Connection(
     long SendOct,
     long SendCnt,
     long SendPend,
-    string State,
+    string? State,
     string? LastBlockedBy,
     string? LastBlockedAge,
     long Channels,
@@ -18,13 +18,13 @@ public record Connection(
     string Name,
     string? Address,
     int Port,
-    string PeerHost,
+    string? PeerHost,
     int PeerPort,
     bool Ssl,
     string? PeerCertSubject,
     string? PeerCertIssuer,
     string? PeerCertValidity,
-    string AuthMechanism,
+    string? AuthMechanism,
     string? SslProtocol,
     string? SslKeyExchange,
     string? SslCipher,

--- a/Source/EasyNetQ.Management.Client/Model/PolicyDefinition.cs
+++ b/Source/EasyNetQ.Management.Client/Model/PolicyDefinition.cs
@@ -67,4 +67,8 @@ public record PolicyDefinition
 
     [property: JsonPropertyName("queue-mode")]
     string? QueueMode = null
-);
+)
+{
+    [JsonExtensionData()]
+    public Dictionary<string, object>? ExtensionData { get; set; }
+};

--- a/Source/EasyNetQ.Management.Client/Model/Queue.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Queue.cs
@@ -6,7 +6,7 @@ public record Queue(
     string Name,
     string Vhost,
     QueueType Type,
-    string Node,
+    string? Node,
     string? State,
     IReadOnlyDictionary<string, object?> Arguments,
     bool Durable,

--- a/Source/EasyNetQ.Management.Client/Model/Queue.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Queue.cs
@@ -1,33 +1,39 @@
 using System.Text.Json.Serialization;
-using EasyNetQ.Management.Client.Serialization;
 
 namespace EasyNetQ.Management.Client.Model;
 
 public record Queue(
+    string Name,
+    string Vhost,
+    QueueType Type,
+    string Node,
+    string? State,
+    IReadOnlyDictionary<string, object?> Arguments,
+    bool Durable,
+    bool Exclusive,
+    bool AutoDelete,
+    long MessagesReady,
+    long MessagesUnacknowledged,
+    long Messages,
+
     long Memory,
     string? IdleSince,
     string? Policy,
     string? ExclusiveConsumerTag,
-    long MessagesReady,
-    long MessagesUnacknowledged,
-    long Messages,
+    long MessageBytes,
     long Consumers,
     long ActiveConsumers,
     BackingQueueStatus? BackingQueueStatus,
     IReadOnlyList<ConsumerDetail>? ConsumerDetails,
     long? HeadMessageTimestamp,
-    string Name,
-    string Vhost,
-    bool Durable,
-    bool Exclusive,
-    bool AutoDelete,
-    [property: JsonConverter(typeof(StringObjectReadOnlyDictionaryConverter))]
-    IReadOnlyDictionary<string, object?> Arguments,
-    string? Node,
     IReadOnlyList<string>? SlaveNodes,
     IReadOnlyList<string>? SynchronisedSlaveNodes,
     LengthsDetails? MessagesDetails,
     LengthsDetails? MessagesReadyDetails,
     LengthsDetails? MessagesUnacknowledgedDetails,
     MessageStats? MessageStats
-);
+) : QueueWithoutStats(Name, Vhost, Type, Node, State, Arguments, Durable, Exclusive, AutoDelete, MessagesReady, MessagesUnacknowledged, Messages)
+{
+    [JsonExtensionData()]
+    public Dictionary<string, object>? ExtensionData { get; set; }
+};

--- a/Source/EasyNetQ.Management.Client/Model/QueueType.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueType.cs
@@ -1,0 +1,8 @@
+namespace EasyNetQ.Management.Client.Model;
+
+public enum QueueType
+{
+    Classic,
+    Quorum,
+    Stream
+}

--- a/Source/EasyNetQ.Management.Client/Model/QueueWithoutStats.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueWithoutStats.cs
@@ -8,7 +8,7 @@ public record QueueWithoutStats(
     string Vhost,
 
     QueueType Type,
-    string Node,
+    string? Node,
     string? State,
     [property: JsonConverter(typeof(StringObjectReadOnlyDictionaryConverter))]
     IReadOnlyDictionary<string, object?> Arguments,

--- a/Source/EasyNetQ.Management.Client/Model/QueueWithoutStats.cs
+++ b/Source/EasyNetQ.Management.Client/Model/QueueWithoutStats.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+using EasyNetQ.Management.Client.Serialization;
+
+namespace EasyNetQ.Management.Client.Model;
+
+public record QueueWithoutStats(
+    string Name,
+    string Vhost,
+
+    QueueType Type,
+    string Node,
+    string? State,
+    [property: JsonConverter(typeof(StringObjectReadOnlyDictionaryConverter))]
+    IReadOnlyDictionary<string, object?> Arguments,
+    bool Durable,
+    bool Exclusive,
+    bool AutoDelete,
+    long MessagesReady,
+    long MessagesUnacknowledged,
+    long Messages
+) : QueueName(Name, Vhost);


### PR DESCRIPTION
Support custom policy definitions in GET and PUT.
Support unmapped queue stats.

Add IManagementClient.GetQueuesWithoutStatsAsync

http://localhost:15672/api/index.html
> It is possible to disable the statistics in the GET requests and obtain just the basic information of every object. This reduces considerably the amount of data returned and the memory and resource consumption of each query in the system. For some monitoring and operation purposes, these queries are more appropiate. The query string parameter `disable_stats` set to `true` will achieve this.


I expect more comments this time :)
I don't commit` approved.txt` until when.

More changes can follow this PR, once approved.

1. All extensions that receive `Queue queue` parameter can be changed to receive `QueueName queueName`.
2. More records (everyone that's returned by `GetAsync`?) should also have `[JsonExtensionData()]`. But also in those that are used in `PutAsync` and `PostAsync` - to allow easy workaround for any missing or recently added property.
3. Extensions should be organized... Maybe one file for Async extensions and another one for sync ones. Coverage should also be tested by `GeneratePublicApi` for `ManagementClient` and `ManagementClientExtensions`, some simple string replaces and equality assertion.

But let's discuss this one first.