### PR TITLE
Fix GetObjectValue for ValueKind.Number

### DIFF
--- a/Source/EasyNetQ.Management.Client/Serialization/ObjectHelpers.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/ObjectHelpers.cs
@@ -73,7 +73,7 @@ internal static class ObjectHelpers
             case { ValueKind: JsonValueKind.False }:
                 return False;
             case { ValueKind: JsonValueKind.Number }:
-                return jsonElement.TryGetInt64(out var longValue) ? longValue : jsonElement.GetDouble();
+                return jsonElement.TryGetInt64(out var longValue) ? (object)longValue : jsonElement.GetDouble();
             case { ValueKind: JsonValueKind.String }:
                 {
                     var stringValue = jsonElement.GetString();


### PR DESCRIPTION
https://github.com/EasyNetQ/EasyNetQ.Management.Client/issues/263

Without explicit cast to `(object)` the returned value is always `double`.