### PR TITLE
Add missing properties to Overview

### DIFF
--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -676,11 +676,18 @@ namespace EasyNetQ.Management.Client.Model
     }
     public class Listener : System.IEquatable<EasyNetQ.Management.Client.Model.Listener>
     {
-        public Listener(string Node, string Protocol, string IpAddress, int Port) { }
+        public Listener(string Node, string Protocol, string IpAddress, int Port, EasyNetQ.Management.Client.Model.SocketOpts? SocketOpts = null) { }
+        [System.Text.Json.Serialization.JsonIgnore]
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? ExtensionData { get; set; }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement>? JsonExtensionData { get; set; }
         public string IpAddress { get; init; }
         public string Node { get; init; }
         public int Port { get; init; }
         public string Protocol { get; init; }
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.EmptyArrayAsDefaultConverter<EasyNetQ.Management.Client.Model.SocketOpts>))]
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public EasyNetQ.Management.Client.Model.SocketOpts? SocketOpts { get; init; }
     }
     public class Message : System.IEquatable<EasyNetQ.Management.Client.Model.Message>
     {
@@ -847,6 +854,10 @@ namespace EasyNetQ.Management.Client.Model
     public class Overview : System.IEquatable<EasyNetQ.Management.Client.Model.Overview>
     {
         public Overview(string ManagementVersion, System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.ExchangeTypeSpec> ExchangeTypes, string RabbitmqVersion, string ErlangVersion, EasyNetQ.Management.Client.Model.MessageStats MessageStats, EasyNetQ.Management.Client.Model.QueueTotals QueueTotals, EasyNetQ.Management.Client.Model.ObjectTotals ObjectTotals, string Node, System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Listener> Listeners, System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Context> Contexts) { }
+        [System.Text.Json.Serialization.JsonIgnore]
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? ExtensionData { get; set; }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement>? JsonExtensionData { get; set; }
         public System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.Context> Contexts { get; init; }
         public string ErlangVersion { get; init; }
         public System.Collections.Generic.IReadOnlyList<EasyNetQ.Management.Client.Model.ExchangeTypeSpec> ExchangeTypes { get; init; }
@@ -1186,6 +1197,20 @@ namespace EasyNetQ.Management.Client.Model
         public int MsgRatesAge { get; init; }
         public int MsgRatesIncr { get; init; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> ToQueryParameters() { }
+    }
+    public class SocketOpts : System.IEquatable<EasyNetQ.Management.Client.Model.SocketOpts>
+    {
+        public SocketOpts(int? Backlog = default, bool? Nodelay = default, bool? ExitOnClose = default) { }
+        [System.Text.Json.Serialization.JsonIgnore]
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? ExtensionData { get; set; }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement>? JsonExtensionData { get; set; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public int? Backlog { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public bool? ExitOnClose { get; init; }
+        [System.Text.Json.Serialization.JsonIgnore(Condition=System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+        public bool? Nodelay { get; init; }
     }
     public class TopicPermission : System.IEquatable<EasyNetQ.Management.Client.Model.TopicPermission>
     {

--- a/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Model/OverviewSerializationTests.cs
@@ -60,7 +60,8 @@ public class OverviewSerializationTests
                             Node: "rabbit@localhost",
                             Protocol: "amqp",
                             IpAddress: "127.0.0.1",
-                            Port: 5672
+                            Port: 5672,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true, ExitOnClose: false)
                         ),
                         new(
                             Node: "rabbit@localhost",
@@ -72,25 +73,29 @@ public class OverviewSerializationTests
                             Node: "rabbit@localhost",
                             Protocol: "http",
                             IpAddress: "::",
-                            Port: 15672
+                            Port: 15672,
+                            SocketOpts: new SocketOpts()
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "mqtt",
                             IpAddress: "::",
-                            Port: 1883
+                            Port: 1883,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "stomp",
                             IpAddress: "::",
-                            Port: 61613
+                            Port: 61613,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "stream",
                             IpAddress: "::",
-                            Port: 5552
+                            Port: 5552,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         )
                     },
                     Contexts: Array.Empty<Context>()
@@ -138,7 +143,8 @@ public class OverviewSerializationTests
                             Node: "rabbit@localhost",
                             Protocol: "amqp",
                             IpAddress: "127.0.0.1",
-                            Port: 5672
+                            Port: 5672,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true, ExitOnClose: false)
                         ),
                         new(
                             Node: "rabbit@localhost",
@@ -150,25 +156,29 @@ public class OverviewSerializationTests
                             Node: "rabbit@localhost",
                             Protocol: "http",
                             IpAddress: "::",
-                            Port: 15672
+                            Port: 15672,
+                            SocketOpts: new SocketOpts()
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "mqtt",
                             IpAddress: "::",
-                            Port: 1883
+                            Port: 1883,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "stomp",
                             IpAddress: "::",
-                            Port: 61613
+                            Port: 61613,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         ),
                         new(
                             Node: "rabbit@localhost",
                             Protocol: "stream",
                             IpAddress: "::",
-                            Port: 5552
+                            Port: 5552,
+                            SocketOpts: new SocketOpts(Backlog: 128, Nodelay: true)
                         )
                     },
                     Contexts: new Context[]
@@ -181,7 +191,14 @@ public class OverviewSerializationTests
                         )
                     }
                 )
-            }
+            },
+            options => options
+                .Excluding(o => o.ExtensionData)
+                .Excluding(o => o.JsonExtensionData)
+                .For(o => o.Listeners).Exclude(l => l.ExtensionData)
+                .For(o => o.Listeners).Exclude(l => l.JsonExtensionData)
+                .For(o => o.Listeners).Exclude(l => l.SocketOpts.ExtensionData)
+                .For(o => o.Listeners).Exclude(l => l.SocketOpts.JsonExtensionData)
         );
     }
 }

--- a/Source/EasyNetQ.Management.Client/Model/Overview.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Overview.cs
@@ -1,4 +1,8 @@
-﻿namespace EasyNetQ.Management.Client.Model;
+﻿using EasyNetQ.Management.Client.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EasyNetQ.Management.Client.Model;
 
 public record Overview(
     string ManagementVersion,
@@ -11,7 +15,18 @@ public record Overview(
     string Node,
     IReadOnlyList<Listener> Listeners,
     IReadOnlyList<Context> Contexts
-);
+)
+{
+    [JsonExtensionData()]
+    public IDictionary<string, JsonElement>? JsonExtensionData { get; set; }
+
+    [JsonIgnore()]
+    public IReadOnlyDictionary<string, object?>? ExtensionData
+    {
+        get { return JsonExtensionDataExtensions.ToExtensionData(JsonExtensionData); }
+        set { JsonExtensionData = JsonExtensionDataExtensions.ToJsonExtensionData(value); }
+    }
+};
 
 public record ObjectTotals(
     int Consumers,

--- a/Source/EasyNetQ.Management.Client/Model/SocketOpts.cs
+++ b/Source/EasyNetQ.Management.Client/Model/SocketOpts.cs
@@ -4,14 +4,13 @@ using System.Text.Json.Serialization;
 
 namespace EasyNetQ.Management.Client.Model;
 
-public record Listener(
-    string Node,
-    string Protocol,
-    string IpAddress,
-    int Port,
-    [property: JsonConverter(typeof(EmptyArrayAsDefaultConverter<SocketOpts>))]
+public record SocketOpts(
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    SocketOpts? SocketOpts = null
+    int? Backlog = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    bool? Nodelay = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    bool? ExitOnClose = null
 )
 {
     [JsonExtensionData()]

--- a/Source/EasyNetQ.Management.Client/Serialization/JsonExtensionDataExtensions.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/JsonExtensionDataExtensions.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+
+namespace EasyNetQ.Management.Client.Serialization;
+
+internal static class JsonExtensionDataExtensions
+{
+    public static IReadOnlyDictionary<string, object?>? ToExtensionData(IDictionary<string, JsonElement>? jsonExtensionData)
+    {
+        Dictionary<string, object?>? dictionary;
+        if (jsonExtensionData == null)
+        {
+            dictionary = null;
+        }
+        else
+        {
+            dictionary = new Dictionary<string, object?>();
+            foreach (var property in jsonExtensionData)
+            {
+                dictionary.Add(property.Key, property.Value.GetObjectValue());
+            }
+        }
+        return dictionary;
+    }
+    public static IDictionary<string, JsonElement>? ToJsonExtensionData(IReadOnlyDictionary<string, object?>? extensionData)
+    {
+        IDictionary<string, JsonElement>? dictionary;
+        if (extensionData == null)
+        {
+            dictionary = null;
+        }
+        else
+        {
+            dictionary = new Dictionary<string, JsonElement>();
+            foreach (var property in extensionData)
+            {
+#if NET6_0_OR_GREATER
+                dictionary.Add(property.Key, JsonSerializer.SerializeToElement(property.Value));
+#else
+                var bytes = JsonSerializer.SerializeToUtf8Bytes(property.Value);
+                dictionary.Add(property.Key, JsonDocument.Parse(bytes).RootElement.Clone());
+#endif
+            }
+        }
+        return dictionary;
+    }
+}


### PR DESCRIPTION
Add `Overview.ExtensionData` to hold all properties that aren't explicitly defined.
Add `Listener.SocketOpts` to hold `socket_opts` and `Listener.ExtensionData` to hold all properties that aren't explicitly defined.
Add SocketOpts with `Backlog`, `Nodelay`, `ExitOnClose` and `ExtensionData` to hold all properties that aren't explicitly defined.