### PR TITLE
BackingQueueStatus.TargetRamCount must support both 0 and "infinity"

### DIFF
--- a/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
+++ b/Source/EasyNetQ.Management.Client.ApprovalTests/EasyNetQ.Management.Client.approved.txt
@@ -324,6 +324,8 @@ namespace EasyNetQ.Management.Client.Model
     public class BackingQueueStatus : System.IEquatable<EasyNetQ.Management.Client.Model.BackingQueueStatus>
     {
         public BackingQueueStatus(
+                    string? Mode,
+                    int Version,
                     int Q1,
                     int Q2,
                     System.Collections.Generic.IReadOnlyList<object?> Delta,
@@ -331,22 +333,29 @@ namespace EasyNetQ.Management.Client.Model
                     int Q4,
                     int Len,
                     int PendingAcks,
-                    string TargetRamCount,
+                    double TargetRamCount,
                     int RamMsgCount,
                     int RamAckCount,
                     long NextSeqId,
+                    long NextDeliverSeqId,
                     int PersistentCount,
                     double AvgIngressRate,
                     double AvgEgressRate,
                     double AvgAckIngressRate,
                     double AvgAckEgressRate) { }
+        [System.Text.Json.Serialization.JsonIgnore]
+        public System.Collections.Generic.IReadOnlyDictionary<string, object?>? ExtensionData { get; set; }
+        [System.Text.Json.Serialization.JsonExtensionData]
+        public System.Collections.Generic.IDictionary<string, System.Text.Json.JsonElement>? JsonExtensionData { get; set; }
         public double AvgAckEgressRate { get; init; }
         public double AvgAckIngressRate { get; init; }
         public double AvgEgressRate { get; init; }
         public double AvgIngressRate { get; init; }
-        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.ObjectReadOnlyListConverter))]
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.ObjectReadOnlyListConverter?))]
         public System.Collections.Generic.IReadOnlyList<object?> Delta { get; init; }
         public int Len { get; init; }
+        public string? Mode { get; init; }
+        public long NextDeliverSeqId { get; init; }
         public long NextSeqId { get; init; }
         public int PendingAcks { get; init; }
         public int PersistentCount { get; init; }
@@ -356,7 +365,9 @@ namespace EasyNetQ.Management.Client.Model
         public int Q4 { get; init; }
         public int RamAckCount { get; init; }
         public int RamMsgCount { get; init; }
-        public string TargetRamCount { get; init; }
+        [System.Text.Json.Serialization.JsonConverter(typeof(EasyNetQ.Management.Client.Serialization.DoubleNamedFloatingPointLiteralsConverter?))]
+        public double TargetRamCount { get; init; }
+        public int Version { get; init; }
     }
     public class Binding : System.IEquatable<EasyNetQ.Management.Client.Model.Binding>
     {

--- a/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
+++ b/Source/EasyNetQ.Management.Client.Tests/Json/Queues.json
@@ -22,7 +22,7 @@
       "q4": 1,
       "len": 1,
       "pending_acks": 0,
-      "target_ram_count": "infinity",
+      "target_ram_count": 0,
       "ram_msg_count": 1,
       "ram_ack_count": 0,
       "next_seq_id": 4,

--- a/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
+++ b/Source/EasyNetQ.Management.Client/Model/BackingQueueStatus.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using EasyNetQ.Management.Client.Serialization;
 
@@ -5,6 +6,8 @@ namespace EasyNetQ.Management.Client.Model;
 
 public record BackingQueueStatus
 (
+    string? Mode,
+    int Version,
     int Q1,
     int Q2,
     [property: JsonConverter(typeof(ObjectReadOnlyListConverter))]
@@ -13,13 +16,26 @@ public record BackingQueueStatus
     int Q4,
     int Len,
     int PendingAcks,
-    string TargetRamCount,
+    [property: JsonConverter(typeof(DoubleNamedFloatingPointLiteralsConverter))]
+    double TargetRamCount,
     int RamMsgCount,
     int RamAckCount,
     long NextSeqId,
+    long NextDeliverSeqId,
     int PersistentCount,
     double AvgIngressRate,
     double AvgEgressRate,
     double AvgAckIngressRate,
     double AvgAckEgressRate
-);
+)
+{
+    [JsonExtensionData()]
+    public IDictionary<string, JsonElement>? JsonExtensionData { get; set; }
+
+    [JsonIgnore()]
+    public IReadOnlyDictionary<string, object?>? ExtensionData
+    {
+        get { return JsonExtensionDataExtensions.ToExtensionData(JsonExtensionData); }
+        set { JsonExtensionData = JsonExtensionDataExtensions.ToJsonExtensionData(value); }
+    }
+};

--- a/Source/EasyNetQ.Management.Client/Serialization/DoubleNamedFloatingPointLiteralsConverter.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/DoubleNamedFloatingPointLiteralsConverter.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EasyNetQ.Management.Client.Serialization;
+
+internal class DoubleNamedFloatingPointLiteralsConverter : JsonConverter<double>
+{
+    private readonly string PositiveInfinity = "Infinity";
+    private readonly string NegativeInfinity = "-Infinity";
+    private readonly string NaN = "NaN";
+
+    public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            string? stringValue = reader.GetString();
+            if (string.Equals(stringValue, PositiveInfinity, StringComparison.OrdinalIgnoreCase))
+            {
+                return double.PositiveInfinity;
+            }
+            else if (string.Equals(stringValue, NegativeInfinity, StringComparison.OrdinalIgnoreCase))
+            {
+                return double.NegativeInfinity;
+            }
+            else if (string.Equals(stringValue, NaN, StringComparison.OrdinalIgnoreCase))
+            {
+                return double.NaN;
+            }
+            else
+            {
+                throw new JsonException($"Expected floating point literal ({PositiveInfinity}, {NegativeInfinity} or {NaN}), but was {stringValue}");
+            }
+        }
+
+        return reader.GetDouble();
+    }
+
+    public override void Write(Utf8JsonWriter writer, double value, JsonSerializerOptions options)
+    {
+        switch (value)
+        {
+            case double.PositiveInfinity: writer.WriteStringValue(PositiveInfinity); break;
+            case double.NegativeInfinity: writer.WriteStringValue(NegativeInfinity); break;
+            case double.NaN: writer.WriteStringValue(NaN); break;
+            default: writer.WriteNumberValue(value); break;
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/EasyNetQ/EasyNetQ.Management.Client/issues/260

`JsonSerializerOptions.NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals` can't be used because it allows only **case sensitive** values `"Infinity"`, `"-Infinity"` and `"NaN"`.
