### PR TITLE
EmptyArrayAsDefaultConverter: treat empty object {} as default (null)

### DIFF
--- a/Source/EasyNetQ.Management.Client.Tests/Serialization/EmptyArrayAsDefaultConverterTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Serialization/EmptyArrayAsDefaultConverterTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using EasyNetQ.Management.Client.Model;
+
+namespace EasyNetQ.Management.Client.Tests.Serialization;
+
+public class EmptyArrayAsDefaultConverterTests
+{
+    private const string consumerDetailFormat =
+        """{{"arguments":{0},"channel_details":{0},"ack_required":true,"active":true,"activity_status":"up","consumer_tag":"CT","consumer_timeout":"undefined","exclusive":false,"prefetch_count":0,"queue":{{"name":"Q","vhost":"V"}}}}""";
+
+    private static readonly ConsumerDetail expectedConsumerDetail = new ConsumerDetail(new QueueName("Q", "V"), "CT", false, true, null, null);
+
+    [Fact]
+    public void Should_deserialize_empty_array()
+    {
+        var deserializedObject = JsonSerializer.Deserialize<ConsumerDetail>(string.Format(consumerDetailFormat, "[]"), ManagementClient.SerializerOptions);
+        deserializedObject.Should().BeEquivalentTo(expectedConsumerDetail);
+    }
+
+    [Fact]
+    public void Should_deserialize_empty_object()
+    {
+        var deserializedObject = JsonSerializer.Deserialize<ConsumerDetail>(string.Format(consumerDetailFormat, "{}"), ManagementClient.SerializerOptions);
+        deserializedObject.Should().BeEquivalentTo(expectedConsumerDetail);
+    }
+
+    [Fact]
+    public void Should_deserialize_null()
+    {
+        var deserializedObject = JsonSerializer.Deserialize<ConsumerDetail>(string.Format(consumerDetailFormat, "null"), ManagementClient.SerializerOptions);
+        deserializedObject.Should().BeEquivalentTo(expectedConsumerDetail);
+    }
+
+    [Fact]
+    public void Should_throw_deserialize_non_empty_array()
+    {
+        var action = () => JsonSerializer.Deserialize<ConsumerDetail>(string.Format(consumerDetailFormat, "[1]"), ManagementClient.SerializerOptions);
+        action.Should().ThrowExactly<JsonException>();
+    }
+
+    [Fact]
+    public void Should_throw_deserialize_string()
+    {
+        var action = () => JsonSerializer.Deserialize<ConsumerDetail>("\"consumer_detail\"");
+        action.Should().ThrowExactly<JsonException>();
+    }
+}

--- a/Source/EasyNetQ.Management.Client.Tests/Serialization/EmptyArrayAsDefaultConverterTests.cs
+++ b/Source/EasyNetQ.Management.Client.Tests/Serialization/EmptyArrayAsDefaultConverterTests.cs
@@ -41,7 +41,7 @@ public class EmptyArrayAsDefaultConverterTests
     [Fact]
     public void Should_throw_deserialize_string()
     {
-        var action = () => JsonSerializer.Deserialize<ConsumerDetail>("\"consumer_detail\"");
+        var action = () => JsonSerializer.Deserialize<ConsumerDetail>(string.Format(consumerDetailFormat, "\"consumer_detail\""), ManagementClient.SerializerOptions);
         action.Should().ThrowExactly<JsonException>();
     }
 }

--- a/Source/EasyNetQ.Management.Client/Serialization/EmptyArrayAsDefaultConverter.cs
+++ b/Source/EasyNetQ.Management.Client/Serialization/EmptyArrayAsDefaultConverter.cs
@@ -11,13 +11,14 @@ internal sealed class EmptyArrayAsDefaultConverter<T> : JsonConverter<T>
         var jsonElement = JsonElement.ParseValue(ref reader);
         switch (jsonElement)
         {
-            case { ValueKind: JsonValueKind.Object }:
+            case { ValueKind: JsonValueKind.Object } when jsonElement.EnumerateObject().Any():
                 return jsonElement.Deserialize<T>(options);
-            case { ValueKind: JsonValueKind.Array } when jsonElement.GetArrayLength() > 0:
-                throw new JsonException("Empty array is required");
-            case { ValueKind: JsonValueKind.Array }:
+            case { ValueKind: JsonValueKind.Object }:
+            case { ValueKind: JsonValueKind.Array } when jsonElement.GetArrayLength() == 0:
             case { ValueKind: JsonValueKind.Null }:
                 return default;
+            case { ValueKind: JsonValueKind.Array }:
+                throw new JsonException($"Unexpected value {jsonElement.GetRawText()}");
             default:
                 throw new JsonException($"Unexpected token type {jsonElement.ValueKind}");
         }


### PR DESCRIPTION
https://github.com/EasyNetQ/EasyNetQ.Management.Client/issues/306