### PR TITLE
Run integration tests on RabbitMQ 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        rabbitmq: ['3.12', '3.13']
+        rabbitmq: ['3.12', '3.13', '4.0']
         # os: [ubuntu-latest, windows-latest]
         os: [ubuntu-latest]
         include:

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
@@ -43,10 +43,7 @@ public class DockerProxy : IDisposable
             FromImage = image,
             Tag = tag
         };
-        var progress = new Progress<JSONMessage>(
-            message => {
-                Console.WriteLine(message.ToString());
-            });
+        var progress = new Progress<JSONMessage>(Console.WriteLine);
         await client.Images.CreateImageAsync(createParameters, null, progress, token);
     }
 

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
@@ -43,9 +43,10 @@ public class DockerProxy : IDisposable
             FromImage = image,
             Tag = tag
         };
-        var progress = new Progress<JSONMessage>(message => {
-            Console.WriteLine(message.ToString());
-        });
+        var progress = new Progress<JSONMessage>(
+            message => {
+                Console.WriteLine(message.ToString());
+            });
         await client.Images.CreateImageAsync(createParameters, null, progress, token);
     }
 

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/DockerProxy.cs
@@ -43,7 +43,9 @@ public class DockerProxy : IDisposable
             FromImage = image,
             Tag = tag
         };
-        var progress = new Progress<JSONMessage>(_ => { });
+        var progress = new Progress<JSONMessage>(message => {
+            Console.WriteLine(message.ToString());
+        });
         await client.Images.CreateImageAsync(createParameters, null, progress, token);
     }
 

--- a/Source/EasyNetQ.Management.Client.IntegrationTests/RabbitMQFixture.cs
+++ b/Source/EasyNetQ.Management.Client.IntegrationTests/RabbitMQFixture.cs
@@ -19,16 +19,18 @@ public sealed class RabbitMqFixture : IAsyncLifetime, IDisposable
     public RabbitMqFixture()
     {
         dockerProxy = new DockerProxy();
-        tag = $"{Environment.GetEnvironmentVariable("RABBITMQ_VERSION") ?? "3.13"}-management";
+        tag = $"{Environment.GetEnvironmentVariable("RABBITMQ_VERSION") ?? "4.0"}-management";
     }
 
     public Uri Endpoint { get; private set; } = new("http://localhost:15672");
     public string User { get; private set; } = "guest";
     public string Password { get; private set; } = "guest";
 
-    public IManagementClient ManagementClient { get; private set; }
+    private IManagementClient? managementClient;
+    public IManagementClient ManagementClient => managementClient!;
 
-    public Version RabbitmqVersion { get; private set; }
+    private Version? rabbitmqVersion;
+    public Version RabbitmqVersion => rabbitmqVersion!;
 
     public async Task InitializeAsync()
     {
@@ -45,11 +47,11 @@ public sealed class RabbitMqFixture : IAsyncLifetime, IDisposable
             Endpoint = new Uri($"http://{containerIp}:15672");
         }
 
-        ManagementClient = new ManagementClient(Endpoint, User, Password);
+        managementClient = new ManagementClient(Endpoint, User, Password);
         await WaitForRabbitMqReadyAsync(cts.Token);
 
         var overview = await ManagementClient.GetOverviewAsync();
-        RabbitmqVersion = new Version(overview.RabbitmqVersion);
+        rabbitmqVersion = new Version(overview.RabbitmqVersion);
     }
 
     public async Task DisposeAsync()


### PR DESCRIPTION
1. Multiple policies tests removed - all **PolicyDefinition** properties are covered together in `Should_be_able_to_create_all_the_definitions_in_a_policy`.
2. `HaveAnyClassicQueuesWithoutSynchronisedMirrorsAsync` is obsolete in 4.0.
https://www.rabbitmq.com/docs/whats-new#classic-queue-mirroring-is-removed
3. `HaMode`, `HaSyncMode`, `HaPromote` policy definitions are obsolete in 4.0.
https://www.rabbitmq.com/docs/3.13/parameters#why-operator-policies-exist
4. Annoying false positive null dereference build warnings removed (RabbitMQFixture.cs).