### PR TITLE
Bump Microsoft.CodeAnalysis.Analyzers from 3.3.4 to 3.11.0 (with code fixes)

### DIFF
--- a/Source/EasyNetQ.Management.Client.ExtensionsGenerator/EasyNetQ.Management.Client.ExtensionsGenerator.csproj
+++ b/Source/EasyNetQ.Management.Client.ExtensionsGenerator/EasyNetQ.Management.Client.ExtensionsGenerator.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
     <PackageReference Include="PolySharp" Version="1.14.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/EasyNetQ.Management.Client.ExtensionsGenerator/ExtensionsGenerator.cs
+++ b/Source/EasyNetQ.Management.Client.ExtensionsGenerator/ExtensionsGenerator.cs
@@ -5,124 +5,120 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace EasyNetQ.Management.Client.ExtensionsGenerator;
 
 [Generator]
-public class ExtensionsGenerator : ISourceGenerator
+public class ExtensionsGenerator : IIncrementalGenerator
 {
-    public void Execute(GeneratorExecutionContext context)
+    public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var compilation = context.Compilation;
-
-        string typeName = "EasyNetQ.Management.Client.IManagementClient";
-        string typeExtensionsName = $"{typeName}Extensions";
-
-        var typeNames = new List<string> { typeName, typeExtensionsName };
-        var types = typeNames.Select(tn => compilation.GetTypeByMetadataName(tn) ?? throw new KeyNotFoundException(tn));
-
-        Dictionary<string, CompilationUnitSyntax> compilationUnits = new();
-
-        var thisParameter = "this IManagementClient client".GetParameterSyntax();
-        QualifiedNameSyntax extensionsClassName = (SyntaxFactory.ParseTypeName(typeExtensionsName) as QualifiedNameSyntax)!;
-
-        {
-            var fileScopedNamespaceDeclaration = SyntaxFactory.FileScopedNamespaceDeclaration(extensionsClassName.Left)
-                .WithLeadingTrivia(SyntaxFactory.Trivia(SyntaxFactory.NullableDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.EnableKeyword), true)));
-
-            foreach (var t in types)
-            {
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", "Vhost vhost", "vhost.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", null, "exchange.Vhost"),
-                        ("string exchangeName", "ExchangeName exchange", "exchange.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", null, "queue.Vhost"),
-                        ("string queueName", "QueueName queue", "queue.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", null, "exchange.Vhost"),
-                        ("string exchangeName", "ExchangeName exchange", "exchange.Name"),
-                        ("string queueName", "QueueName queue", "queue.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", null, "sourceExchange.Vhost"),
-                        ("string sourceExchangeName", "ExchangeName sourceExchange", "sourceExchange.Name"),
-                        ("string destinationExchangeName", "ExchangeName destinationExchange", "destinationExchange.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string connectionName", "Connection connection", "connection.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string userName", "User user", "user.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string vhostName", "Vhost vhost", "vhost.Name"),
-                        ("string userName", "User user", "user.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string componentName", null, "parameter.Component"),
-                        ("string vhostName", null, "parameter.Vhost"),
-                        ("string parameterName", "Parameter parameter", "parameter.Name")
-                     );
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
-                        ("string componentName", null, "parameter.Component"),
-                        ("string vhostName", null, "parameter.Vhost"),
-                        ("string parameterName", null, "parameter.Name"),
-                        ("object parameterValue", "Parameter parameter", "parameter.Value")
-                     );
-            }
-
-            var compilationUnit = SyntaxFactory.CompilationUnit()
-                .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("EasyNetQ.Management.Client.Model")))
-                .AddMembers(fileScopedNamespaceDeclaration)
-                .NormalizeWhitespace(eol: "\n");
-
-            compilationUnits[$"{extensionsClassName.Right}Replacement"] = compilationUnit;
-
-            compilation = compilation.AddSyntaxTrees(compilationUnit.SyntaxTree);
-        }
-
-        {
-            var fileScopedNamespaceDeclaration = SyntaxFactory.FileScopedNamespaceDeclaration(extensionsClassName.Left)
-                .WithLeadingTrivia(SyntaxFactory.Trivia(SyntaxFactory.NullableDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.EnableKeyword), true)));
-
-            foreach (var t in types)
-            {
-                fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
-                    .AddSyncExtensionsClass(extensionsClassName, t, thisParameter);
-            }
-
-            var compilationUnit = SyntaxFactory.CompilationUnit()
-                .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("EasyNetQ.Management.Client.Model")))
-                .AddMembers(fileScopedNamespaceDeclaration)
-                .NormalizeWhitespace(eol: "\n");
-
-            compilationUnits[$"{extensionsClassName.Right}Sync"] = compilationUnit;
-        }
-
-        foreach (var kvpair in compilationUnits)
-        {
-            context.AddSource($"{kvpair.Key}.g.cs", kvpair.Value.ToString());
-        }
-    }
-
-    public void Initialize(GeneratorInitializationContext context)
-    {
-        // No initialization required for this one
-
         // if (!System.Diagnostics.Debugger.IsAttached)
         // {
         //     System.Diagnostics.Debugger.Launch();
         // }
+
+        context.RegisterSourceOutput(context.CompilationProvider, (context, compilation) =>
+        {
+            string typeName = "EasyNetQ.Management.Client.IManagementClient";
+            string typeExtensionsName = $"{typeName}Extensions";
+
+            var typeNames = new List<string> { typeName, typeExtensionsName };
+            var types = typeNames.Select(tn => compilation.GetTypeByMetadataName(tn) ?? throw new KeyNotFoundException(tn));
+
+            Dictionary<string, CompilationUnitSyntax> compilationUnits = new();
+
+            var thisParameter = "this IManagementClient client".GetParameterSyntax();
+            QualifiedNameSyntax extensionsClassName = (SyntaxFactory.ParseTypeName(typeExtensionsName) as QualifiedNameSyntax)!;
+
+            {
+                var fileScopedNamespaceDeclaration = SyntaxFactory.FileScopedNamespaceDeclaration(extensionsClassName.Left)
+                    .WithLeadingTrivia(SyntaxFactory.Trivia(SyntaxFactory.NullableDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.EnableKeyword), true)));
+
+                foreach (var t in types)
+                {
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", "Vhost vhost", "vhost.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", null, "exchange.Vhost"),
+                            ("string exchangeName", "ExchangeName exchange", "exchange.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", null, "queue.Vhost"),
+                            ("string queueName", "QueueName queue", "queue.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", null, "exchange.Vhost"),
+                            ("string exchangeName", "ExchangeName exchange", "exchange.Name"),
+                            ("string queueName", "QueueName queue", "queue.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", null, "sourceExchange.Vhost"),
+                            ("string sourceExchangeName", "ExchangeName sourceExchange", "sourceExchange.Name"),
+                            ("string destinationExchangeName", "ExchangeName destinationExchange", "destinationExchange.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string connectionName", "Connection connection", "connection.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string userName", "User user", "user.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string vhostName", "Vhost vhost", "vhost.Name"),
+                            ("string userName", "User user", "user.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string componentName", null, "parameter.Component"),
+                            ("string vhostName", null, "parameter.Vhost"),
+                            ("string parameterName", "Parameter parameter", "parameter.Name")
+                         );
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddReplacementExtensionsClass(extensionsClassName, t, thisParameter,
+                            ("string componentName", null, "parameter.Component"),
+                            ("string vhostName", null, "parameter.Vhost"),
+                            ("string parameterName", null, "parameter.Name"),
+                            ("object parameterValue", "Parameter parameter", "parameter.Value")
+                         );
+                }
+
+                var compilationUnit = SyntaxFactory.CompilationUnit()
+                    .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("EasyNetQ.Management.Client.Model")))
+                    .AddMembers(fileScopedNamespaceDeclaration)
+                    .NormalizeWhitespace(eol: "\n");
+
+                compilationUnits[$"{extensionsClassName.Right}Replacement"] = compilationUnit;
+
+                compilation = compilation.AddSyntaxTrees(compilationUnit.SyntaxTree);
+            }
+
+            {
+                var fileScopedNamespaceDeclaration = SyntaxFactory.FileScopedNamespaceDeclaration(extensionsClassName.Left)
+                    .WithLeadingTrivia(SyntaxFactory.Trivia(SyntaxFactory.NullableDirectiveTrivia(SyntaxFactory.Token(SyntaxKind.EnableKeyword), true)));
+
+                foreach (var t in types)
+                {
+                    fileScopedNamespaceDeclaration = fileScopedNamespaceDeclaration
+                        .AddSyncExtensionsClass(extensionsClassName, t, thisParameter);
+                }
+
+                var compilationUnit = SyntaxFactory.CompilationUnit()
+                    .AddUsings(SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("EasyNetQ.Management.Client.Model")))
+                    .AddMembers(fileScopedNamespaceDeclaration)
+                    .NormalizeWhitespace(eol: "\n");
+
+                compilationUnits[$"{extensionsClassName.Right}Sync"] = compilationUnit;
+            }
+
+            foreach (var kvpair in compilationUnits)
+            {
+                context.AddSource($"{kvpair.Key}.g.cs", kvpair.Value.ToString());
+            }
+        });
     }
 }

--- a/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
+++ b/Source/EasyNetQ.Management.Client/EasyNetQ.Management.Client.csproj
@@ -39,6 +39,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+    <EmitCompilerGeneratedFiles Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'Debug'">true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes are inspired by

https://stackoverflow.com/questions/79105325/error-rs1035-the-symbol-is-banned-for-use-by-analyzers-while-using-generatorex