### PR TITLE
Don't include the Request Headers in the UnexpectedHttpStatusCodeException message anymore

### DIFF
--- a/Source/EasyNetQ.Management.Client/UnexpectedHttpStatusCodeException.cs
+++ b/Source/EasyNetQ.Management.Client/UnexpectedHttpStatusCodeException.cs
@@ -63,9 +63,20 @@ public class UnexpectedHttpStatusCodeException : Exception
             sb.Append("<null>");
         }
         sb.Append(" from request: ");
-        if (response.RequestMessage != null)
+        var request = response.RequestMessage;
+        if (request != null)
         {
-            sb.Append(response.RequestMessage);
+            sb.Append("Method: ");
+            sb.Append(request.Method.ToString());
+
+            sb.Append(", RequestUri: '");
+            sb.Append(request.RequestUri == null ? "<null>" : request.RequestUri.ToString());
+
+            sb.Append("', Version: ");
+            sb.Append(request.Version.ToString());
+
+            sb.Append(", Content: ");
+            sb.Append(request.Content == null ? "<null>" : request.Content.GetType().ToString());
         }
         else
         {


### PR DESCRIPTION
Resolves #368

I basically looked at the [HttpRequestMessage.ToString](https://github.com/dotnet/runtime/blob/fce8ed90dc43047eabec2b32c04ee46b789ad5d1/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs#L142) and replicated it, except for the Headers appending part.

At first, I wanted to only redact/censor the individual values for sensitive Headers but that got too annoying. The DumpHeaders method is internal and replicating it seemed wrong. Then I tried cloning the RequestMessage object but with redacted headers and simply doing ToString on that object, but cloning the Content is really weird... Then I thought about a Regex Replace on the result string... 😑 yeah, nope.

So I just pushed this solution, that doesn't include any Headers at all. Maybe no one even cares about the Header values in general and I don't need to put more time into this.

Message before:
```
Unexpected response: StatusCode: 400 BadRequest, Content: '{"error":"bad_request","reason":"Cast from Array(JSON::Any) to String failed"}' from request: Method: PUT, RequestUri: 'http://host.docker.internal:15672/api/users/test', Version: 1.1, Content: System.Net.Http.Json.JsonContent, Headers:
{
  Authorization: Basic Z3Vlc3Q6Z3Vlc3Q=
  Transfer-Encoding: chunked
  Content-Type: application/json
}
```
Now:
```
Unexpected response: StatusCode: 400 BadRequest, Content: '{"error":"bad_request","reason":"Cast from Array(JSON::Any) to String failed"}' from request: Method: PUT, RequestUri: 'http://host.docker.internal:15672/api/users/test', Version: 1.1, Content: System.Net.Http.Json.JsonContent
```