### PR TITLE
Make Type field in Connection nullable to fix mismatch in JSON schema

### DIFF
--- a/Source/EasyNetQ.Management.Client/Model/Connection.cs
+++ b/Source/EasyNetQ.Management.Client/Model/Connection.cs
@@ -13,7 +13,7 @@ public record Connection(
     string? LastBlockedBy,
     string? LastBlockedAge,
     long Channels,
-    string Type,
+    string? Type,
     string Node,
     string Name,
     string? Address,


### PR DESCRIPTION
Due to changes in RabbitMQ 4.1 the Type field in Connection has seemingly become optional.
This caused the GetConnectionsAsync method to throw an exception.

I've tested the fix on a private NuGet feed initially to make sure it works, and it has solved the issue I had with it.